### PR TITLE
Add hook OnBigWheelLoss

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -7926,6 +7926,30 @@
             "BaseHookName": null,
             "HookCategory": "_Patches"
           }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 63,
+            "ReturnBehavior": 0,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, l8",
+            "HookTypeName": "Simple",
+            "Name": "OnBigWheelLoss",
+            "HookName": "OnBigWheelLoss",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "BigWheelGame",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "Payout",
+              "ReturnType": "System.Void",
+              "Parameters": []
+            },
+            "MSILHash": "AN3Y9M83Owfjbcds1Yv6YHo6X4fl37GMjApk3gQdImE=",
+            "BaseHookName": null,
+            "HookCategory": "Item"
+          }
         }
       ],
       "Modifiers": [


### PR DESCRIPTION
Implemented & tested new hook for the BigWheelGame object. This hook will be called from the Payout method inside of BigWheelGame. It will server function for showing when players lose their bets. The hook contains the BigWheelGame object and the gambled item as it's parameters.