### PR TITLE
Fixed IOnServerUsersSet and IOnServerUsersRemove

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -3603,7 +3603,7 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 0,
+            "InjectionIndex": 16,
             "ReturnBehavior": 0,
             "ArgumentBehavior": 2,
             "ArgumentString": null,
@@ -4890,7 +4890,7 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 0,
+            "InjectionIndex": 5,
             "ReturnBehavior": 0,
             "ArgumentBehavior": 2,
             "ArgumentString": null,


### PR DESCRIPTION
Moved IOnServerUsersSet so it is called after the user is removed, as opposed to before it.
Moved IOnServerUsersRemove so it is called right before the user is removed.