### PR TITLE
Added OnFlameTurretFire and OnShotgunTrapFire hooks.

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -1929,6 +1929,54 @@
         {
           "Type": "Simple",
           "Hook": {
+            "InjectionIndex": 94,
+            "ReturnBehavior": 3,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, l4 => l2",
+            "HookTypeName": "Simple",
+            "Name": "OnFlameTurretFire",
+            "HookName": "OnFlameTurretFire",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "FlameTurret",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "CheckTrigger",
+              "ReturnType": "System.Boolean",
+              "Parameters": []
+            },
+            "MSILHash": "QCrsm4a9Cwo8zNG0bzJPfaPf8iKnSEGz/4nV+vAPJ00=",
+            "BaseHookName": null,
+            "HookCategory": "Entity"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 70,
+            "ReturnBehavior": 3,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, l4 => l2",
+            "HookTypeName": "Simple",
+            "Name": "OnShotgunTrapFire",
+            "HookName": "OnShotgunTrapFire",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "GunTrap",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "CheckTrigger",
+              "ReturnType": "System.Boolean",
+              "Parameters": []
+            },
+            "MSILHash": "lCKuiaTWOrkBy5zEgGRWJuIjIGBbRx8BySQex9btYUo=",
+            "BaseHookName": null,
+            "HookCategory": "Entity"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
             "InjectionIndex": 0,
             "ReturnBehavior": 1,
             "ArgumentBehavior": 3,


### PR DESCRIPTION
Both of these hooks pass 'this' as the first parameter (FlameTurret or GunTrap) and the target BasePlayer as the second parameter. Returning false prevents the trap from firing. Returning true (or null) allows the trap to fire.

Example plugin code:

```
bool OnFlameTurretFire(FlameTurret turret, BasePlayer player)
{
	Puts("OnFlameTurretFire called! Allowing flame turret to fire.");
	return true;
}

bool OnShotgunTrapFire(GunTrap turret, BasePlayer player)
{
	Puts("OnShotgunTrapFire called! Not allowing shotgun trap to fire.");
	return false; 
}
```

This isn't quite as fully featured as the existing hooks for `AutoTurret`, but it's better than nothing.

These hooks will be of particular use to my [Turret Limits plugin](https://umod.org/plugins/turret-limits) as it will allow me to prevent traps from firing without an active electricity supply in the base.