### PR TITLE
Add hook OnSamSiteTargeted

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -4237,7 +4237,7 @@
             "HookName": "OnRecycleItem [patch]",
             "AssemblyName": "Assembly-CSharp.dll",
             "TypeName": "Recycler",
-            "Flagged": false,
+            "Flagged": true,
             "Signature": {
               "Exposure": 2,
               "Name": "RecycleThink",
@@ -6640,7 +6640,7 @@
             "HookName": "OnLootPlayer",
             "AssemblyName": "Assembly-CSharp.dll",
             "TypeName": "BasePlayer",
-            "Flagged": false,
+            "Flagged": true,
             "Signature": {
               "Exposure": 2,
               "Name": "RPC_LootPlayer",

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -3502,7 +3502,7 @@
             "InjectionIndex": 0,
             "ReturnBehavior": 1,
             "ArgumentBehavior": 4,
-            "ArgumentString": "this, msg.player",
+            "ArgumentString": "this, a0.player",
             "HookTypeName": "Simple",
             "Name": "OnRotateVendingMachine",
             "HookName": "OnRotateVendingMachine",

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -659,7 +659,7 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 914,
+            "InjectionIndex": 882,
             "ReturnBehavior": 1,
             "ArgumentBehavior": 4,
             "ArgumentString": "this, l2",
@@ -677,7 +677,7 @@
                 "BaseEntity/RPCMessage"
               ]
             },
-            "MSILHash": "dTHPJ8yGm0AvICFA62667IalZsOwa3oFcLtiU/SwX4g=",
+            "MSILHash": "qGXKLwLB/gUWsggFttswywXh/WrzbdRZhFyxL+nIJHk=",
             "BaseHookName": null,
             "HookCategory": "Player"
           }
@@ -730,7 +730,7 @@
                 "Network.Connection"
               ]
             },
-            "MSILHash": "AIuhaSnlHQ6mJtwpxk6uI5pRRw63rhwFFq9rbHpzF0I=",
+            "MSILHash": "CLVm3l9dDmKTKjBg5oCOgoQ7L6wVil2vnkgJqB6OdwY=",
             "BaseHookName": null,
             "HookCategory": "Player"
           }
@@ -947,7 +947,7 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 42,
+            "InjectionIndex": 45,
             "ReturnBehavior": 0,
             "ArgumentBehavior": 1,
             "ArgumentString": null,
@@ -963,7 +963,7 @@
               "ReturnType": "System.Void",
               "Parameters": []
             },
-            "MSILHash": "fGrwr0li+7FCQzf7MXDaHD7CQwHwKgf20CjXNscG7l0=",
+            "MSILHash": "bxiW0e4r+qZQ/ixgNT/QftCVJRSzzh7ADVKcLb1GVWQ=",
             "BaseHookName": null,
             "HookCategory": "Player"
           }
@@ -1118,7 +1118,7 @@
                 "HitInfo"
               ]
             },
-            "MSILHash": "VKqhOyOsrHfERz4YLIHjMWXvY40DUysN8ByLafoVMYc=",
+            "MSILHash": "WX6FIsPNXoqP3BwX0lFLhMipnNalx2sVm6LBPk+JmCU=",
             "BaseHookName": null,
             "HookCategory": "Player"
           }
@@ -1178,7 +1178,7 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 147,
+            "InjectionIndex": 145,
             "ReturnBehavior": 0,
             "ArgumentBehavior": 4,
             "ArgumentString": "a0, l1",
@@ -1196,7 +1196,7 @@
                 "ItemCraftTask"
               ]
             },
-            "MSILHash": "kH0usIlPDBORJez4kW8ogE3lOG19qhsmPNfzW7ABTBw=",
+            "MSILHash": "xwlleEv8IUHTVSIQqSOiTdxVfq9ScYhw+50sR0smbO8=",
             "BaseHookName": null,
             "HookCategory": "Item"
           }
@@ -1358,7 +1358,7 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 216,
+            "InjectionIndex": 223,
             "ReturnBehavior": 0,
             "ArgumentBehavior": 4,
             "ArgumentString": "l0, l8",
@@ -1376,7 +1376,7 @@
                 "BaseEntity/RPCMessage"
               ]
             },
-            "MSILHash": "Vo5MLFd5RwGCN1zlf/qlKpnyRGLQ7boYqWyGkz8PPFY=",
+            "MSILHash": "PeDugO4Bi8+n8jSHOZSgZaegDPtNPcScGdPovPBI2Uk=",
             "BaseHookName": null,
             "HookCategory": "Weapon"
           }
@@ -1402,7 +1402,7 @@
                 "BaseEntity/RPCMessage"
               ]
             },
-            "MSILHash": "jpGESaKn1vRV3thiPBWV9ui9yPOATuWiS5s0FZn9sYA=",
+            "MSILHash": "dgd8sk6vRuXiAJxEDxeodx6IX5STFA7zGMjTHccR/As=",
             "BaseHookName": null,
             "HookCategory": "Weapon"
           }
@@ -1504,7 +1504,7 @@
             },
             "MSILHash": "U8X0WIP/tTq33l+6Ke/on8yYnKW31iymfql4eT+OQaw=",
             "BaseHookName": null,
-            "HookCategory": "Resource"
+            "HookCategory": "__Broken__"
           }
         },
         {
@@ -1660,7 +1660,7 @@
             },
             "MSILHash": "DahR9iHXV/BZN7dY+tt5T4UjEhZSYaIj6KpFcsKMNNg=",
             "BaseHookName": null,
-            "HookCategory": "Item"
+            "HookCategory": "__Broken__"
           }
         },
         {
@@ -2059,32 +2059,6 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 20,
-            "ReturnBehavior": 1,
-            "ArgumentBehavior": 4,
-            "ArgumentString": "this, l1",
-            "HookTypeName": "Simple",
-            "Name": "OnPlayerLand",
-            "HookName": "OnPlayerLand",
-            "AssemblyName": "Assembly-CSharp.dll",
-            "TypeName": "BasePlayer",
-            "Flagged": false,
-            "Signature": {
-              "Exposure": 0,
-              "Name": "OnPlayerLanded",
-              "ReturnType": "System.Void",
-              "Parameters": [
-                "BaseEntity/RPCMessage"
-              ]
-            },
-            "MSILHash": "WfjFSqcstSVzMjihJYdW2sRQN5zmHV5zScigKY384MI=",
-            "BaseHookName": null,
-            "HookCategory": "Player"
-          }
-        },
-        {
-          "Type": "Simple",
-          "Hook": {
             "InjectionIndex": 0,
             "ReturnBehavior": 1,
             "ArgumentBehavior": 3,
@@ -2271,7 +2245,7 @@
               "ReturnType": "System.Void",
               "Parameters": []
             },
-            "MSILHash": "+5o9fm5e/nUb1WmLWXOPSCAI0ouBoIKx4r5FvgWWTtc=",
+            "MSILHash": "3Hb2wI371ob2C39yx64OrrEUjJKfOBZCqELiESUsxkQ=",
             "BaseHookName": null,
             "HookCategory": "_Patches"
           }
@@ -2431,7 +2405,7 @@
                 "Item"
               ]
             },
-            "MSILHash": "KPzLKIxbmMW8fG4OG4FAmf9LSmqOJPxSWsjJCbiQX1M=",
+            "MSILHash": "rLJKbVp70JjUTUfNrML37oxakzhTvt3O9ImpgYTjhvY=",
             "BaseHookName": null,
             "HookCategory": "Weapon"
           }
@@ -2591,7 +2565,7 @@
                 "System.UInt64"
               ]
             },
-            "MSILHash": "DiLxz3x+/hHtHIXM4lBalav0FH5b8j+vm6MLYVEYBsc=",
+            "MSILHash": "fLHHmyr0IjE9z1nG/ijHOnJuK7XH8BjB2GfKyEJ3xiY=",
             "BaseHookName": null,
             "HookCategory": "Server"
           }
@@ -2675,7 +2649,7 @@
                 "Network.Message"
               ]
             },
-            "MSILHash": "M1lFVmiCqwsaU6ncuj2YUbsGweWdOAGG7gpTax7lRr4=",
+            "MSILHash": "IoH41udXxx8MM/4Ax+9sgERAeLWcE9Wj0JgAw550fqc=",
             "BaseHookName": null,
             "HookCategory": "Player"
           }
@@ -2702,35 +2676,9 @@
                 "System.Boolean"
               ]
             },
-            "MSILHash": "PoqqZGv74vAvQo8UewLryVgaedO9gK0X3AzcyRMbntY=",
+            "MSILHash": "tOtlb53xTDaMxUl+HBde0Ursomf6O7L4d9u2UdFgIRU=",
             "BaseHookName": null,
             "HookCategory": "Server"
-          }
-        },
-        {
-          "Type": "Simple",
-          "Hook": {
-            "InjectionIndex": 62,
-            "ReturnBehavior": 0,
-            "ArgumentBehavior": 4,
-            "ArgumentString": "this, l1",
-            "HookTypeName": "Simple",
-            "Name": "OnPlayerLanded",
-            "HookName": "OnPlayerLanded",
-            "AssemblyName": "Assembly-CSharp.dll",
-            "TypeName": "BasePlayer",
-            "Flagged": false,
-            "Signature": {
-              "Exposure": 0,
-              "Name": "OnPlayerLanded",
-              "ReturnType": "System.Void",
-              "Parameters": [
-                "BaseEntity/RPCMessage"
-              ]
-            },
-            "MSILHash": "WfjFSqcstSVzMjihJYdW2sRQN5zmHV5zScigKY384MI=",
-            "BaseHookName": "OnPlayerLand",
-            "HookCategory": "Player"
           }
         },
         {
@@ -2779,7 +2727,7 @@
                 "System.Boolean"
               ]
             },
-            "MSILHash": "PoqqZGv74vAvQo8UewLryVgaedO9gK0X3AzcyRMbntY=",
+            "MSILHash": "tOtlb53xTDaMxUl+HBde0Ursomf6O7L4d9u2UdFgIRU=",
             "BaseHookName": "OnNewSave",
             "HookCategory": "Server"
           }
@@ -2803,7 +2751,7 @@
               "ReturnType": "System.Void",
               "Parameters": []
             },
-            "MSILHash": "rbB7PmS1Y3JFMJDug+212WqLj2Boc/bJXwO9YNbQ9sY=",
+            "MSILHash": "j9qavMA2ZAyLO1XGs0JdvUT5PuwetXfPtAxJvSM4+Z0=",
             "BaseHookName": null,
             "HookCategory": "Player"
           }
@@ -2984,7 +2932,7 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 45,
+            "InjectionIndex": 4,
             "ReturnBehavior": 0,
             "ArgumentBehavior": 1,
             "ArgumentString": null,
@@ -3000,7 +2948,7 @@
               "ReturnType": "System.Void",
               "Parameters": []
             },
-            "MSILHash": "UAt7R+IW8fUEhrTEuChH8QuQW/QnVCmdOas8PSvTwn8=",
+            "MSILHash": "bVFkTfwmGLriwUJn8Z86aVsL87atobRoCWhCZe09Jv0=",
             "BaseHookName": null,
             "HookCategory": "Player"
           }
@@ -3232,7 +3180,7 @@
             },
             "MSILHash": "QCrsm4a9Cwo8zNG0bzJPfaPf8iKnSEGz/4nV+vAPJ00=",
             "BaseHookName": null,
-            "HookCategory": "Player"
+            "HookCategory": "__Broken__"
           }
         },
         {
@@ -3441,7 +3389,7 @@
             },
             "MSILHash": "wJjvWeKLT/NWi+9XnLA7XJi9m434JmZ71SgQKky4LKg=",
             "BaseHookName": null,
-            "HookCategory": "Vending"
+            "HookCategory": "__Broken__"
           }
         },
         {
@@ -4246,7 +4194,7 @@
             },
             "MSILHash": "wSd4Lwg85uzdoHKZCno+/AZoNhsAk3zCVFaNVUd2tSk=",
             "BaseHookName": "OnRecycleItem",
-            "HookCategory": "_Patches"
+            "HookCategory": "__Broken__"
           }
         },
         {
@@ -4656,7 +4604,7 @@
             },
             "MSILHash": "lCKuiaTWOrkBy5zEgGRWJuIjIGBbRx8BySQex9btYUo=",
             "BaseHookName": null,
-            "HookCategory": "Player"
+            "HookCategory": "__Broken__"
           }
         },
         {
@@ -4728,7 +4676,7 @@
                 "BaseEntity/RPCMessage"
               ]
             },
-            "MSILHash": "cu36huukvp+w0JRhHm6IEKTFNVjz+bOACjyyUZR8Ns4=",
+            "MSILHash": "wQ+ICwpAOHN8oVNXdjbu4UVpcxDJ3PEu2WywdfQ5nMk=",
             "BaseHookName": null,
             "HookCategory": "Weapon"
           }
@@ -4750,9 +4698,11 @@
               "Exposure": 1,
               "Name": "ReloadMagazine",
               "ReturnType": "System.Void",
-              "Parameters": []
+              "Parameters": [
+                "System.Int32"
+              ]
             },
-            "MSILHash": "leemnH9bjSC3S+9e9r8WF+x0+b2hB4S79sErdHO7Y/s=",
+            "MSILHash": "J85QCub4di16mJl1Oca8ibEGl4fvf9hKx3rmcDo+Ebk=",
             "BaseHookName": null,
             "HookCategory": "Weapon"
           }
@@ -5316,7 +5266,7 @@
             },
             "MSILHash": "wJjvWeKLT/NWi+9XnLA7XJi9m434JmZ71SgQKky4LKg=",
             "BaseHookName": "OnRefreshVendingStock [blueprint]",
-            "HookCategory": "Vending"
+            "HookCategory": "__Broken__"
           }
         },
         {
@@ -5524,7 +5474,7 @@
                 "Item"
               ]
             },
-            "MSILHash": "KPzLKIxbmMW8fG4OG4FAmf9LSmqOJPxSWsjJCbiQX1M=",
+            "MSILHash": "rLJKbVp70JjUTUfNrML37oxakzhTvt3O9ImpgYTjhvY=",
             "BaseHookName": "CanCreateWorldProjectile",
             "HookCategory": "Weapon"
           }
@@ -5648,7 +5598,7 @@
             },
             "MSILHash": "QCrsm4a9Cwo8zNG0bzJPfaPf8iKnSEGz/4nV+vAPJ00=",
             "BaseHookName": "CanBeTargeted [flameturret]",
-            "HookCategory": "_Patches"
+            "HookCategory": "__Broken__"
           }
         },
         {
@@ -5692,7 +5642,7 @@
             },
             "MSILHash": "lCKuiaTWOrkBy5zEgGRWJuIjIGBbRx8BySQex9btYUo=",
             "BaseHookName": "CanBeTargeted [guntrap]",
-            "HookCategory": "_Patches"
+            "HookCategory": "__Broken__"
           }
         },
         {
@@ -6150,7 +6100,7 @@
             },
             "MSILHash": "Y4TCpueeO8M72L7n6CQlAhdcK2OXdZRdTJH27jC3e98=",
             "BaseHookName": null,
-            "HookCategory": "Entity"
+            "HookCategory": "__Broken__"
           }
         },
         {
@@ -6285,7 +6235,7 @@
               "ReturnType": "System.Void",
               "Parameters": []
             },
-            "MSILHash": "nINFsRSYIH4lILvSVZBPOkxq3nPCxDIGuKFykNeKioE=",
+            "MSILHash": "k6b4SLIrgo+NPSb+dvkqJgV4MfFEjsxmnFOXq3lIwY8=",
             "BaseHookName": null,
             "HookCategory": "Entity"
           }
@@ -6651,7 +6601,7 @@
             },
             "MSILHash": "PuQPoN4go462lXs+1P6tk4GvthDirt0vwV+UfGqXvFw=",
             "BaseHookName": null,
-            "HookCategory": "Player"
+            "HookCategory": "__Broken__"
           }
         },
         {
@@ -6675,7 +6625,7 @@
             },
             "MSILHash": "fxQJavxOM8Va4MQCdBmEKC+fnUZb7xBualsmqZe6nh4=",
             "BaseHookName": null,
-            "HookCategory": "Weapon"
+            "HookCategory": "__Broken__"
           }
         },
         {
@@ -6686,7 +6636,7 @@
             "ArgumentBehavior": 4,
             "ArgumentString": "this, l1",
             "HookTypeName": "Simple",
-            "Name": "OnFlameExplosion",
+            "Name": "OnFlameExplosion [broken]",
             "HookName": "OnFlameExplosion",
             "AssemblyName": "Assembly-CSharp.dll",
             "TypeName": "FlameExplosive",
@@ -6701,7 +6651,7 @@
             },
             "MSILHash": "8rr2VSawA+BBAqENFQ72qgYUQCfevQxQ3KtL2lQJCA8=",
             "BaseHookName": null,
-            "HookCategory": "Entity"
+            "HookCategory": "__Broken__"
           }
         },
         {
@@ -6725,7 +6675,7 @@
             },
             "MSILHash": "kbfuDpDzAXyYQYSlO3scgP1MVAb2h3jpu5lo4Y6bxCw=",
             "BaseHookName": null,
-            "HookCategory": "Entity"
+            "HookCategory": "__Broken__"
           }
         },
         {
@@ -6749,7 +6699,7 @@
             },
             "MSILHash": "WAdUho0ZGAAf8N4EQggkN98zjxMm5A4D1XGbTMh8ubc=",
             "BaseHookName": null,
-            "HookCategory": "Entity"
+            "HookCategory": "__Broken__"
           }
         },
         {
@@ -6800,7 +6750,7 @@
                 "ConsoleSystem/Arg"
               ]
             },
-            "MSILHash": "eYFQZ4ZKL4A5hZLcaMhpg5sKhIneJTCzjX+uR4k17tI=",
+            "MSILHash": "f7/u9kweTwkUqh3IskKPD37BAec7fXJVAP9ToRL4/p0=",
             "BaseHookName": null,
             "HookCategory": "Player"
           }
@@ -6826,7 +6776,7 @@
                 "ConsoleSystem/Arg"
               ]
             },
-            "MSILHash": "eYFQZ4ZKL4A5hZLcaMhpg5sKhIneJTCzjX+uR4k17tI=",
+            "MSILHash": "f7/u9kweTwkUqh3IskKPD37BAec7fXJVAP9ToRL4/p0=",
             "BaseHookName": "IOnPlayerCommand [internal]",
             "HookCategory": "Player"
           }
@@ -7144,7 +7094,7 @@
             },
             "MSILHash": "/nEuvnw+JQmAu0tQUMVatcE+LV/V32o2o2HJf3ec34Q=",
             "BaseHookName": null,
-            "HookCategory": "Entity"
+            "HookCategory": "__Broken__"
           }
         },
         {
@@ -7215,7 +7165,7 @@
             "ArgumentBehavior": 4,
             "ArgumentString": "this, a0",
             "HookTypeName": "Simple",
-            "Name": "OnNpcPlayerTarget [animals]",
+            "Name": "OnNpcPlayerTarget [animals, broken]",
             "HookName": "OnNpcPlayerTarget",
             "AssemblyName": "Assembly-CSharp.dll",
             "TypeName": "Rust.Ai.HTN.BaseNpcMemory",
@@ -7285,7 +7235,7 @@
             },
             "MSILHash": "66fWKhBmLgHOrluqq5bQWpxJ3AcyX52NU+Ljdfl0c+o=",
             "BaseHookName": null,
-            "HookCategory": "Entity"
+            "HookCategory": "__Broken__"
           }
         },
         {
@@ -7313,7 +7263,7 @@
             },
             "MSILHash": "M5QSAh4W32SQcwq/dndv+Npto1ZYMIZyBV2cpzq/7P4=",
             "BaseHookName": null,
-            "HookCategory": "Entity"
+            "HookCategory": "__Broken__"
           }
         },
         {
@@ -7573,7 +7523,7 @@
             },
             "MSILHash": "NB7aDVxtM6Pcx0xoSjNUxhgjfYs84oTSJYQcqFpoyf0=",
             "BaseHookName": "OnTeamCreate",
-            "HookCategory": "Team"
+            "HookCategory": "__Broken__"
           }
         },
         {
@@ -7925,6 +7875,58 @@
             "MSILHash": "N+8KQI012/z3UtI6P6EAkadxLBonXARkWwOF5gQXzu8=",
             "BaseHookName": null,
             "HookCategory": "_Patches"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 9,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, l0",
+            "HookTypeName": "Simple",
+            "Name": "OnPlayerLand",
+            "HookName": "OnPlayerLand",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "BasePlayer",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "ApplyFallDamageFromVelocity",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "System.Single"
+              ]
+            },
+            "MSILHash": "XAbBUjv9aYi01AmWlvIJ98FqWYe3fbF070HqXQjRTuM=",
+            "BaseHookName": null,
+            "HookCategory": "Player"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 51,
+            "ReturnBehavior": 0,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, l0",
+            "HookTypeName": "Simple",
+            "Name": "OnPlayerLanded",
+            "HookName": "OnPlayerLanded",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "BasePlayer",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "ApplyFallDamageFromVelocity",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "System.Single"
+              ]
+            },
+            "MSILHash": "XAbBUjv9aYi01AmWlvIJ98FqWYe3fbF070HqXQjRTuM=",
+            "BaseHookName": "OnPlayerLand",
+            "HookCategory": "Player"
           }
         }
       ],

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -1649,7 +1649,7 @@
             "HookName": "OnItemRepair",
             "AssemblyName": "Assembly-CSharp.dll",
             "TypeName": "RepairBench",
-            "Flagged": true,
+            "Flagged": false,
             "Signature": {
               "Exposure": 2,
               "Name": "RepairItem",
@@ -6141,7 +6141,7 @@
             "HookName": "IOnNpcTarget",
             "AssemblyName": "Assembly-CSharp.dll",
             "TypeName": "BaseNpc",
-            "Flagged": true,
+            "Flagged": false,
             "Signature": {
               "Exposure": 0,
               "Name": "AggroClosestEnemy",
@@ -6584,7 +6584,7 @@
             "HookName": "ItemMaxStackableMove [patch]",
             "AssemblyName": "Assembly-CSharp.dll",
             "TypeName": "PlayerInventory",
-            "Flagged": true,
+            "Flagged": false,
             "Signature": {
               "Exposure": 0,
               "Name": "MoveItem",
@@ -6640,7 +6640,7 @@
             "HookName": "OnLootPlayer",
             "AssemblyName": "Assembly-CSharp.dll",
             "TypeName": "BasePlayer",
-            "Flagged": true,
+            "Flagged": false,
             "Signature": {
               "Exposure": 2,
               "Name": "RPC_LootPlayer",
@@ -6666,7 +6666,7 @@
             "HookName": "OnFlameThrowerBurn",
             "AssemblyName": "Assembly-CSharp.dll",
             "TypeName": "FlameThrower",
-            "Flagged": true,
+            "Flagged": false,
             "Signature": {
               "Exposure": 2,
               "Name": "FlameTick",
@@ -6690,7 +6690,7 @@
             "HookName": "OnFlameExplosion",
             "AssemblyName": "Assembly-CSharp.dll",
             "TypeName": "FlameExplosive",
-            "Flagged": true,
+            "Flagged": false,
             "Signature": {
               "Exposure": 2,
               "Name": "Explode",
@@ -6716,7 +6716,7 @@
             "HookName": "OnFireBallDamage",
             "AssemblyName": "Assembly-CSharp.dll",
             "TypeName": "FireBall",
-            "Flagged": true,
+            "Flagged": false,
             "Signature": {
               "Exposure": 2,
               "Name": "DoRadialDamage",
@@ -6740,7 +6740,7 @@
             "HookName": "OnFireBallSpread",
             "AssemblyName": "Assembly-CSharp.dll",
             "TypeName": "FireBall",
-            "Flagged": true,
+            "Flagged": false,
             "Signature": {
               "Exposure": 2,
               "Name": "TryToSpread",
@@ -6843,7 +6843,7 @@
             "HookName": "OnNpcPlayerResume",
             "AssemblyName": "Assembly-CSharp.dll",
             "TypeName": "NPCPlayerApex",
-            "Flagged": true,
+            "Flagged": false,
             "Signature": {
               "Exposure": 2,
               "Name": "Resume",

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -11103,6 +11103,63 @@
             "Parameters": []
           },
           "MSILHash": ""
+        },
+        {
+          "Name": "SamSite::lockOnTime",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "SamSite",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "lockOnTime",
+            "FullTypeName": "System.Single SamSite::lockOnTime",
+            "Parameters": []
+          },
+          "MSILHash": ""
+        },
+        {
+          "Name": "SamSite::lastTargetVisibleTime",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "SamSite",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "lastTargetVisibleTime",
+            "FullTypeName": "System.Single SamSite::lastTargetVisibleTime",
+            "Parameters": []
+          },
+          "MSILHash": ""
+        },
+        {
+          "Name": "SamSite::nextBurstTime",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "SamSite",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "nextBurstTime",
+            "FullTypeName": "System.Single SamSite::nextBurstTime",
+            "Parameters": []
+          },
+          "MSILHash": ""
         }
       ],
       "Fields": [

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -1,6 +1,6 @@
 {
   "Name": "Rust",
-  "TargetDirectory": "D:\\Servers\\Rust-staging\\RustDedicated_Data\\Managed",
+  "TargetDirectory": "D:\\Servers\\Rust\\RustDedicated_Data\\Managed",
   "Manifests": [
     {
       "AssemblyName": "Assembly-CSharp.dll",

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -11160,6 +11160,25 @@
             "Parameters": []
           },
           "MSILHash": ""
+        },
+        {
+          "Name": "BasePlayer::firedProjectiles",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "BasePlayer",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "firedProjectiles",
+            "FullTypeName": "System.Collections.Generic.Dictionary`2<System.Int32,BasePlayer/FiredProjectile> BasePlayer::firedProjectiles",
+            "Parameters": []
+          },
+          "MSILHash": ""
         }
       ],
       "Fields": [

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -3603,7 +3603,7 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 0,
+            "InjectionIndex": 16,
             "ReturnBehavior": 0,
             "ArgumentBehavior": 2,
             "ArgumentString": null,
@@ -4890,7 +4890,7 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 0,
+            "InjectionIndex": 5,
             "ReturnBehavior": 0,
             "ArgumentBehavior": 2,
             "ArgumentString": null,

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -7961,7 +7961,7 @@
             "InjectionIndex": 21,
             "ReturnBehavior": 1,
             "ArgumentBehavior": 4,
-            "ArgumentString": "a0.player, l0",
+            "ArgumentString": "a0.player, l0, l2",
             "HookTypeName": "Simple",
             "Name": "CanDeployItem",
             "HookName": "CanDeployItem",

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -7961,7 +7961,7 @@
             "InjectionIndex": 21,
             "ReturnBehavior": 1,
             "ArgumentBehavior": 4,
-            "ArgumentString": "a0.player, l0, l2",
+            "ArgumentString": "a0.player, this, l2",
             "HookTypeName": "Simple",
             "Name": "CanDeployItem",
             "HookName": "CanDeployItem",

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -7619,7 +7619,7 @@
                 "Operand": "mscorlib|System.OperatingSystem|get_Platform"
               },
               {
-                "OpCode": "ldc_i4_2",
+                "OpCode": "ldc_i4_4",
                 "OpType": "None",
                 "Operand": null
               },
@@ -7629,7 +7629,7 @@
                 "Operand": null
               },
               {
-                "OpCode": "brfalse",
+                "OpCode": "brtrue",
                 "OpType": "Instruction",
                 "Operand": 29
               }
@@ -7668,7 +7668,7 @@
                 "Operand": "mscorlib|System.OperatingSystem|get_Platform"
               },
               {
-                "OpCode": "ldc_i4_2",
+                "OpCode": "ldc_i4_4",
                 "OpType": "None",
                 "Operand": null
               },
@@ -7678,7 +7678,7 @@
                 "Operand": null
               },
               {
-                "OpCode": "brfalse",
+                "OpCode": "brtrue",
                 "OpType": "Instruction",
                 "Operand": 69
               }
@@ -7721,7 +7721,7 @@
                 "Operand": "mscorlib|System.OperatingSystem|get_Platform"
               },
               {
-                "OpCode": "ldc_i4_2",
+                "OpCode": "ldc_i4_4",
                 "OpType": "None",
                 "Operand": null
               },
@@ -7731,7 +7731,7 @@
                 "Operand": null
               },
               {
-                "OpCode": "brfalse",
+                "OpCode": "brtrue",
                 "OpType": "Instruction",
                 "Operand": 13
               }
@@ -7770,7 +7770,7 @@
                 "Operand": "mscorlib|System.OperatingSystem|get_Platform"
               },
               {
-                "OpCode": "ldc_i4_2",
+                "OpCode": "ldc_i4_4",
                 "OpType": "None",
                 "Operand": null
               },
@@ -7780,7 +7780,7 @@
                 "Operand": null
               },
               {
-                "OpCode": "brfalse",
+                "OpCode": "brtrue",
                 "OpType": "Instruction",
                 "Operand": 49
               }
@@ -7821,7 +7821,7 @@
                 "Operand": "mscorlib|System.OperatingSystem|get_Platform"
               },
               {
-                "OpCode": "ldc_i4_2",
+                "OpCode": "ldc_i4_4",
                 "OpType": "None",
                 "Operand": null
               },
@@ -7831,7 +7831,7 @@
                 "Operand": null
               },
               {
-                "OpCode": "brfalse",
+                "OpCode": "brtrue",
                 "OpType": "Instruction",
                 "Operand": 8
               }
@@ -7870,7 +7870,7 @@
                 "Operand": "mscorlib|System.OperatingSystem|get_Platform"
               },
               {
-                "OpCode": "ldc_i4_2",
+                "OpCode": "ldc_i4_4",
                 "OpType": "None",
                 "Operand": null
               },
@@ -7880,7 +7880,7 @@
                 "Operand": null
               },
               {
-                "OpCode": "brfalse",
+                "OpCode": "brtrue",
                 "OpType": "Instruction",
                 "Operand": 5
               }

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -7343,6 +7343,266 @@
           }
         },
         {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 13,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "l0",
+            "HookTypeName": "Simple",
+            "Name": "OnTeamCreate",
+            "HookName": "OnTeamCreate",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "RelationshipManager",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "trycreateteam",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "ConsoleSystem/Arg"
+              ]
+            },
+            "MSILHash": "NB7aDVxtM6Pcx0xoSjNUxhgjfYs84oTSJYQcqFpoyf0=",
+            "BaseHookName": null,
+            "HookCategory": "Team"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 57,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "l0, l4",
+            "HookTypeName": "Simple",
+            "Name": "OnTeamInvite",
+            "HookName": "OnTeamInvite",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "RelationshipManager",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "sendinvite",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "ConsoleSystem/Arg"
+              ]
+            },
+            "MSILHash": "GXrf9FdZIEjVTK85fSM3b/SpI5s7axqNqryes8EnzbA=",
+            "BaseHookName": null,
+            "HookCategory": "Team"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 27,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "l0, l2",
+            "HookTypeName": "Simple",
+            "Name": "OnTeamRejectInvite",
+            "HookName": "OnTeamRejectInvite",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "RelationshipManager",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "rejectinvite",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "ConsoleSystem/Arg"
+              ]
+            },
+            "MSILHash": "uIbLOC3SlGAlCrFcu0ubw4OEUJ/Tx4wvVvZEAlJsptw=",
+            "BaseHookName": null,
+            "HookCategory": "Team"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 42,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "l2, l1",
+            "HookTypeName": "Simple",
+            "Name": "OnTeamPromote",
+            "HookName": "OnTeamPromote",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "RelationshipManager",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "promote",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "ConsoleSystem/Arg"
+              ]
+            },
+            "MSILHash": "GXlJ4gJv8JbJLBVt0IP+sPnjJ4WbWRZMD/Z0p6umDJQ=",
+            "BaseHookName": null,
+            "HookCategory": "Team"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 19,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "l1, l0",
+            "HookTypeName": "Simple",
+            "Name": "OnTeamLeave",
+            "HookName": "OnTeamLeave",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "RelationshipManager",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "leaveteam",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "ConsoleSystem/Arg"
+              ]
+            },
+            "MSILHash": "z8DXgEwPWd7fXMR7CQdonUOAEAhqmvjuNnNxWiBEPlg=",
+            "BaseHookName": null,
+            "HookCategory": "Team"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 33,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "l1, l0",
+            "HookTypeName": "Simple",
+            "Name": "OnTeamKick",
+            "HookName": "OnTeamKick",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "RelationshipManager",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "kickmember",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "ConsoleSystem/Arg"
+              ]
+            },
+            "MSILHash": "wHDqeNNNzhem0KkCJMHGycJKBH2oTtAKNNvxIa8iLio=",
+            "BaseHookName": null,
+            "HookCategory": "Team"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 27,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "l2, l0",
+            "HookTypeName": "Simple",
+            "Name": "OnTeamAcceptInvite",
+            "HookName": "OnTeamAcceptInvite",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "RelationshipManager",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "acceptinvite",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "ConsoleSystem/Arg"
+              ]
+            },
+            "MSILHash": "1NEji1Ol00WtkEN+F/QToC8s5sjn4IckQAMHEGTA714=",
+            "BaseHookName": null,
+            "HookCategory": "Team"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 0,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 2,
+            "ArgumentString": null,
+            "HookTypeName": "Simple",
+            "Name": "OnTeamDisband",
+            "HookName": "OnTeamDisband",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "RelationshipManager",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "DisbandTeam",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "RelationshipManager/PlayerTeam"
+              ]
+            },
+            "MSILHash": "WZHEB/VqQkOQYyVXGSDX4woN796b/5HTs4xAQqmmUXc=",
+            "BaseHookName": null,
+            "HookCategory": "Team"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 28,
+            "ReturnBehavior": 0,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "l0, l1",
+            "HookTypeName": "Simple",
+            "Name": "OnTeamCreated",
+            "HookName": "OnTeamCreated",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "RelationshipManager",
+            "Flagged": true,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "trycreateteam",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "ConsoleSystem/Arg"
+              ]
+            },
+            "MSILHash": "NB7aDVxtM6Pcx0xoSjNUxhgjfYs84oTSJYQcqFpoyf0=",
+            "BaseHookName": "OnTeamCreate",
+            "HookCategory": "Team"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 12,
+            "ReturnBehavior": 0,
+            "ArgumentBehavior": 2,
+            "ArgumentString": null,
+            "HookTypeName": "Simple",
+            "Name": "OnTeamDisbanded",
+            "HookName": "OnTeamDisbanded",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "RelationshipManager",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "DisbandTeam",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "RelationshipManager/PlayerTeam"
+              ]
+            },
+            "MSILHash": "WZHEB/VqQkOQYyVXGSDX4woN796b/5HTs4xAQqmmUXc=",
+            "BaseHookName": "OnTeamDisband",
+            "HookCategory": "Team"
+          }
+        },
+        {
           "Type": "Modify",
           "Hook": {
             "InjectionIndex": 0,

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -11179,6 +11179,25 @@
             "Parameters": []
           },
           "MSILHash": ""
+        },
+        {
+          "Name": "BasePlayer/FiredProjectile",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "BasePlayer/FiredProjectile",
+          "Type": 3,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "FiredProjectile",
+            "FullTypeName": "BasePlayer/FiredProjectile",
+            "Parameters": []
+          },
+          "MSILHash": ""
         }
       ],
       "Fields": [

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -499,7 +499,7 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 100,
+            "InjectionIndex": 107,
             "ReturnBehavior": 0,
             "ArgumentBehavior": 4,
             "ArgumentString": "this, l1",
@@ -519,7 +519,7 @@
                 "System.UInt32"
               ]
             },
-            "MSILHash": "KeqqPZW4dzkLctq+AFFZCVqS/hsFEauwW+ejYVqGcto=",
+            "MSILHash": "krG4H8P7CU1G/WvGybUrMNuHhQImrV/27n542OE5BlI=",
             "BaseHookName": null,
             "HookCategory": "Item"
           }
@@ -659,7 +659,7 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 882,
+            "InjectionIndex": 999,
             "ReturnBehavior": 1,
             "ArgumentBehavior": 4,
             "ArgumentString": "this, l2",
@@ -677,7 +677,7 @@
                 "BaseEntity/RPCMessage"
               ]
             },
-            "MSILHash": "qGXKLwLB/gUWsggFttswywXh/WrzbdRZhFyxL+nIJHk=",
+            "MSILHash": "rbxzM+UXoeDGJKxHcUzQyvAe9Hetj7ASsC7TeBIvNEE=",
             "BaseHookName": null,
             "HookCategory": "Player"
           }

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -3156,7 +3156,7 @@
             },
             "MSILHash": "bcyJmGroXTIUU3OPYSNHGVkJ5PbaEAS/WksDoe8zpxU=",
             "BaseHookName": null,
-            "HookCategory": "Server"
+            "HookCategory": "World"
           }
         },
         {
@@ -7927,6 +7927,139 @@
             "MSILHash": "XAbBUjv9aYi01AmWlvIJ98FqWYe3fbF070HqXQjRTuM=",
             "BaseHookName": "OnPlayerLand",
             "HookCategory": "Player"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 37,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "l0, this",
+            "HookTypeName": "Simple",
+            "Name": "CanPushBoat",
+            "HookName": "CanPushBoat",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "MotorRowboat",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "RPC_WantsPush",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "BaseEntity/RPCMessage"
+              ]
+            },
+            "MSILHash": "T2E58SMg0QDjlD12ilDCFL9p1zT8qmN+HJmwol5fj34=",
+            "BaseHookName": null,
+            "HookCategory": "Player"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 21,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "a0.player, l0",
+            "HookTypeName": "Simple",
+            "Name": "CanDeployItem",
+            "HookName": "CanDeployItem",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "Deployer",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 0,
+              "Name": "DoDeploy",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "BaseEntity/RPCMessage"
+              ]
+            },
+            "MSILHash": "SkVCRyntL+yn+a3fXLiH4lCfsU68Yu4SHZeAdMbDimk=",
+            "BaseHookName": null,
+            "HookCategory": "Player"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 61,
+            "ReturnBehavior": 0,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, l8",
+            "HookTypeName": "Simple",
+            "Name": "OnBigWheelLoss",
+            "HookName": "OnBigWheelLoss",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "BigWheelGame",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "Payout",
+              "ReturnType": "System.Void",
+              "Parameters": []
+            },
+            "MSILHash": "AN3Y9M83Owfjbcds1Yv6YHo6X4fl37GMjApk3gQdImE=",
+            "BaseHookName": null,
+            "HookCategory": "Entity"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 12,
+            "ReturnBehavior": 0,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "l0, a0",
+            "HookTypeName": "Simple",
+            "Name": "OnWorldPrefabSpawned",
+            "HookName": "OnWorldPrefabSpawned",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "World",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 0,
+              "Name": "Spawn",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "System.String",
+                "System.UInt32",
+                "UnityEngine.Vector3",
+                "UnityEngine.Quaternion",
+                "UnityEngine.Vector3"
+              ]
+            },
+            "MSILHash": "3WG5GI59jmn7KSSui18gYW4m84aEKPye1EwvATFDcXI=",
+            "BaseHookName": null,
+            "HookCategory": "World"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 0,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 1,
+            "ArgumentString": null,
+            "HookTypeName": "Simple",
+            "Name": "OnBoatPathGenerate",
+            "HookName": "OnBoatPathGenerate",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "BaseBoat",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "GenerateOceanPatrolPath",
+              "ReturnType": "System.Collections.Generic.List`1<UnityEngine.Vector3>",
+              "Parameters": [
+                "System.Single",
+                "System.Single"
+              ]
+            },
+            "MSILHash": "6w4stUt6n3+3vU3xhEStULnO+GY923iX1oa0EpdPssA=",
+            "BaseHookName": null,
+            "HookCategory": "Vehicle"
           }
         }
       ],

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -8008,6 +8008,30 @@
         {
           "Type": "Simple",
           "Hook": {
+            "InjectionIndex": 40,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 1,
+            "ArgumentString": null,
+            "HookTypeName": "Simple",
+            "Name": "CanSamSiteShoot",
+            "HookName": "CanSamSiteShoot",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "SamSite",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "WeaponTick",
+              "ReturnType": "System.Void",
+              "Parameters": []
+            },
+            "MSILHash": "UEuh5wug5rmyYj5RnAx3FOuIZ7Q+blYz2n3hEugtAIA=",
+            "BaseHookName": null,
+            "HookCategory": "Entity"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
             "InjectionIndex": 12,
             "ReturnBehavior": 0,
             "ArgumentBehavior": 4,

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -7130,7 +7130,7 @@
             "HookName": "OnNpcPlayerTarget",
             "AssemblyName": "Assembly-CSharp.dll",
             "TypeName": "NPCPlayerApex",
-            "Flagged": false,
+            "Flagged": true,
             "Signature": {
               "Exposure": 2,
               "Name": "UpdateTargetMemory",

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -1486,7 +1486,7 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 111,
+            "InjectionIndex": 112,
             "ReturnBehavior": 0,
             "ArgumentBehavior": 4,
             "ArgumentString": "this, l11",
@@ -6690,7 +6690,7 @@
             "HookName": "OnFlameExplosion",
             "AssemblyName": "Assembly-CSharp.dll",
             "TypeName": "FlameExplosive",
-            "Flagged": false,
+            "Flagged": true,
             "Signature": {
               "Exposure": 2,
               "Name": "Explode",

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -7366,6 +7366,306 @@
             "BaseHookName": "IOnPlayerChat [internal]",
             "HookCategory": "_Patches"
           }
+        },
+        {
+          "Type": "Modify",
+          "Hook": {
+            "InjectionIndex": 0,
+            "RemoveCount": 0,
+            "Instructions": [
+              {
+                "OpCode": "call",
+                "OpType": "Method",
+                "Operand": "mscorlib|System.Environment|get_OSVersion"
+              },
+              {
+                "OpCode": "callvirt",
+                "OpType": "Method",
+                "Operand": "mscorlib|System.OperatingSystem|get_Platform"
+              },
+              {
+                "OpCode": "ldc_i4_2",
+                "OpType": "None",
+                "Operand": null
+              },
+              {
+                "OpCode": "ceq",
+                "OpType": "None",
+                "Operand": null
+              },
+              {
+                "OpCode": "brfalse",
+                "OpType": "Instruction",
+                "Operand": 29
+              }
+            ],
+            "HookTypeName": "Modify",
+            "Name": "ConsoleEnableWinOnly [patch]",
+            "HookName": "ConsoleEnableWinOnly [patch]",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "ServerConsole",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "OnEnable",
+              "ReturnType": "System.Void",
+              "Parameters": []
+            },
+            "MSILHash": "FiSe0dzBG4Gojuwy6thYkYL70dXLZcns6fH3a7zyjb4=",
+            "BaseHookName": null,
+            "HookCategory": "_Patches"
+          }
+        },
+        {
+          "Type": "Modify",
+          "Hook": {
+            "InjectionIndex": 0,
+            "RemoveCount": 0,
+            "Instructions": [
+              {
+                "OpCode": "call",
+                "OpType": "Method",
+                "Operand": "mscorlib|System.Environment|get_OSVersion"
+              },
+              {
+                "OpCode": "callvirt",
+                "OpType": "Method",
+                "Operand": "mscorlib|System.OperatingSystem|get_Platform"
+              },
+              {
+                "OpCode": "ldc_i4_2",
+                "OpType": "None",
+                "Operand": null
+              },
+              {
+                "OpCode": "ceq",
+                "OpType": "None",
+                "Operand": null
+              },
+              {
+                "OpCode": "brfalse",
+                "OpType": "Instruction",
+                "Operand": 69
+              }
+            ],
+            "HookTypeName": "Modify",
+            "Name": "ConsoleHandleLogWinOnly [patch]",
+            "HookName": "ConsoleHandleLogWinOnly [patch]",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "ServerConsole",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 0,
+              "Name": "HandleLog",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "System.String",
+                "System.String",
+                "UnityEngine.LogType"
+              ]
+            },
+            "MSILHash": "zxbUUEBy8Lr/Y2tcsZ9h1DxlmthdQNmp+nvzO/j0VyA=",
+            "BaseHookName": null,
+            "HookCategory": "_Patches"
+          }
+        },
+        {
+          "Type": "Modify",
+          "Hook": {
+            "InjectionIndex": 4,
+            "RemoveCount": 0,
+            "Instructions": [
+              {
+                "OpCode": "call",
+                "OpType": "Method",
+                "Operand": "mscorlib|System.Environment|get_OSVersion"
+              },
+              {
+                "OpCode": "callvirt",
+                "OpType": "Method",
+                "Operand": "mscorlib|System.OperatingSystem|get_Platform"
+              },
+              {
+                "OpCode": "ldc_i4_2",
+                "OpType": "None",
+                "Operand": null
+              },
+              {
+                "OpCode": "ceq",
+                "OpType": "None",
+                "Operand": null
+              },
+              {
+                "OpCode": "brfalse",
+                "OpType": "Instruction",
+                "Operand": 13
+              }
+            ],
+            "HookTypeName": "Modify",
+            "Name": "ConsoleDisableWinOnly [patch]",
+            "HookName": "ConsoleDisableWinOnly [patch]",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "ServerConsole",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 0,
+              "Name": "OnDisable",
+              "ReturnType": "System.Void",
+              "Parameters": []
+            },
+            "MSILHash": "qH0Fx4ZpZ52rsWOYB9nD/cxYExr6N+/oLjCJei6InME=",
+            "BaseHookName": null,
+            "HookCategory": "_Patches"
+          }
+        },
+        {
+          "Type": "Modify",
+          "Hook": {
+            "InjectionIndex": 0,
+            "RemoveCount": 0,
+            "Instructions": [
+              {
+                "OpCode": "call",
+                "OpType": "Method",
+                "Operand": "mscorlib|System.Environment|get_OSVersion"
+              },
+              {
+                "OpCode": "callvirt",
+                "OpType": "Method",
+                "Operand": "mscorlib|System.OperatingSystem|get_Platform"
+              },
+              {
+                "OpCode": "ldc_i4_2",
+                "OpType": "None",
+                "Operand": null
+              },
+              {
+                "OpCode": "ceq",
+                "OpType": "None",
+                "Operand": null
+              },
+              {
+                "OpCode": "brfalse",
+                "OpType": "Instruction",
+                "Operand": 49
+              }
+            ],
+            "HookTypeName": "Modify",
+            "Name": "ConsolePrintWinOnly [patch]",
+            "HookName": "ConsolePrintWinOnly [patch]",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "ServerConsole",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "PrintColoured",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "System.Object[]"
+              ]
+            },
+            "MSILHash": "UI86dHyItG7auqsoY9Zk936ttdcLX2uvBUQ95+KCkEw=",
+            "BaseHookName": null,
+            "HookCategory": "_Patches"
+          }
+        },
+        {
+          "Type": "Modify",
+          "Hook": {
+            "InjectionIndex": 0,
+            "RemoveCount": 0,
+            "Instructions": [
+              {
+                "OpCode": "call",
+                "OpType": "Method",
+                "Operand": "mscorlib|System.Environment|get_OSVersion"
+              },
+              {
+                "OpCode": "callvirt",
+                "OpType": "Method",
+                "Operand": "mscorlib|System.OperatingSystem|get_Platform"
+              },
+              {
+                "OpCode": "ldc_i4_2",
+                "OpType": "None",
+                "Operand": null
+              },
+              {
+                "OpCode": "ceq",
+                "OpType": "None",
+                "Operand": null
+              },
+              {
+                "OpCode": "brfalse",
+                "OpType": "Instruction",
+                "Operand": 8
+              }
+            ],
+            "HookTypeName": "Modify",
+            "Name": "ConsoleInitWinOnly [patch]",
+            "HookName": "ConsoleInitWinOnly [patch]",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "ServerConsole",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": ".ctor",
+              "ReturnType": "System.Void",
+              "Parameters": []
+            },
+            "MSILHash": "hMvSQJ3+3AqlZGiCx6FXHBprcWPcosm5l7BPHVidsBw=",
+            "BaseHookName": null,
+            "HookCategory": "_Patches"
+          }
+        },
+        {
+          "Type": "Modify",
+          "Hook": {
+            "InjectionIndex": 0,
+            "RemoveCount": 0,
+            "Instructions": [
+              {
+                "OpCode": "call",
+                "OpType": "Method",
+                "Operand": "mscorlib|System.Environment|get_OSVersion"
+              },
+              {
+                "OpCode": "callvirt",
+                "OpType": "Method",
+                "Operand": "mscorlib|System.OperatingSystem|get_Platform"
+              },
+              {
+                "OpCode": "ldc_i4_2",
+                "OpType": "None",
+                "Operand": null
+              },
+              {
+                "OpCode": "ceq",
+                "OpType": "None",
+                "Operand": null
+              },
+              {
+                "OpCode": "brfalse",
+                "OpType": "Instruction",
+                "Operand": 5
+              }
+            ],
+            "HookTypeName": "Modify",
+            "Name": "ConsoleUpdateWinOnly [patch]",
+            "HookName": "ConsoleUpdateWinOnly [patch]",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "ServerConsole",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 0,
+              "Name": "Update",
+              "ReturnType": "System.Void",
+              "Parameters": []
+            },
+            "MSILHash": "dbFxdC1i2DngvwowXIPatWsbfbfnyS1CMmTbwcK1Jh8=",
+            "BaseHookName": null,
+            "HookCategory": "_Patches"
+          }
         }
       ],
       "Modifiers": [

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -7641,6 +7641,31 @@
             "BaseHookName": null,
             "HookCategory": "_Patches"
           }
+        },
+        {
+          "Type": "Modify",
+          "Hook": {
+            "InjectionIndex": 210,
+            "RemoveCount": 9,
+            "Instructions": [],
+            "HookTypeName": "Modify",
+            "Name": "AllowNpcAttackingNpc [patch]",
+            "HookName": "AllowNpcAttackingNpc [patch]",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "BaseProjectile",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "ServerUse",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "System.Single"
+              ]
+            },
+            "MSILHash": "N+8KQI012/z3UtI6P6EAkadxLBonXARkWwOF5gQXzu8=",
+            "BaseHookName": null,
+            "HookCategory": "_Patches"
+          }
         }
       ],
       "Modifiers": [

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -6141,7 +6141,7 @@
             "HookName": "IOnNpcTarget",
             "AssemblyName": "Assembly-CSharp.dll",
             "TypeName": "BaseNpc",
-            "Flagged": false,
+            "Flagged": true,
             "Signature": {
               "Exposure": 0,
               "Name": "AggroClosestEnemy",

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -730,7 +730,7 @@
                 "Network.Connection"
               ]
             },
-            "MSILHash": "aQZQPnX03dTDPq/jsEfS82GBz0WrxRO+pbrEETKEn5g=",
+            "MSILHash": "AIuhaSnlHQ6mJtwpxk6uI5pRRw63rhwFFq9rbHpzF0I=",
             "BaseHookName": null,
             "HookCategory": "Player"
           }
@@ -2271,7 +2271,7 @@
               "ReturnType": "System.Void",
               "Parameters": []
             },
-            "MSILHash": "dQnhRUfe7lIh+7JhsTWAFkBFGZ+uaJLnVFnwBKIfLtI=",
+            "MSILHash": "+5o9fm5e/nUb1WmLWXOPSCAI0ouBoIKx4r5FvgWWTtc=",
             "BaseHookName": null,
             "HookCategory": "_Patches"
           }
@@ -2675,7 +2675,7 @@
                 "Network.Message"
               ]
             },
-            "MSILHash": "/K8LF87g+qm+Muko2fmVBKBp9RQmfGSCbtWTkKCoscU=",
+            "MSILHash": "M1lFVmiCqwsaU6ncuj2YUbsGweWdOAGG7gpTax7lRr4=",
             "BaseHookName": null,
             "HookCategory": "Player"
           }

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -8032,6 +8032,30 @@
         {
           "Type": "Simple",
           "Hook": {
+            "InjectionIndex": 105,
+            "ReturnBehavior": 0,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "l1, this",
+            "HookTypeName": "Simple",
+            "Name": "OnSamSiteTargeted",
+            "HookName": "OnSamSiteTargeted",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "SamSite",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "TargetScan",
+              "ReturnType": "System.Void",
+              "Parameters": []
+            },
+            "MSILHash": "xYGSp+PrJ9Bu/gFbtTxe3ugNFWGwuUugv7a6hESblns=",
+            "BaseHookName": null,
+            "HookCategory": "Entity"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
             "InjectionIndex": 12,
             "ReturnBehavior": 0,
             "ArgumentBehavior": 4,

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -10870,6 +10870,82 @@
             "Parameters": []
           },
           "MSILHash": ""
+        },
+        {
+          "Name": "BasePlayer::cachedCraftLevel",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "BasePlayer",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "cachedCraftLevel",
+            "FullTypeName": "System.Single BasePlayer::cachedCraftLevel",
+            "Parameters": []
+          },
+          "MSILHash": ""
+        },
+        {
+          "Name": "BasePlayer::cachedThreatLevel",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "BasePlayer",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "cachedThreatLevel",
+            "FullTypeName": "System.Single BasePlayer::cachedThreatLevel",
+            "Parameters": []
+          },
+          "MSILHash": ""
+        },
+        {
+          "Name": "BasePlayer::cachedProtection",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "BasePlayer",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "cachedProtection",
+            "FullTypeName": "ProtectionProperties BasePlayer::cachedProtection",
+            "Parameters": []
+          },
+          "MSILHash": ""
+        },
+        {
+          "Name": "BasePlayer::nextCheckTime",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "BasePlayer",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "nextCheckTime",
+            "FullTypeName": "System.Single BasePlayer::nextCheckTime",
+            "Parameters": []
+          },
+          "MSILHash": ""
         }
       ],
       "Fields": [

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -3291,7 +3291,7 @@
             "InjectionIndex": 111,
             "ReturnBehavior": 0,
             "ArgumentBehavior": 4,
-            "ArgumentString": "a0.player, l3",
+            "ArgumentString": "a0.player, l2",
             "HookTypeName": "Simple",
             "Name": "OnExplosiveDropped",
             "HookName": "OnExplosiveDropped",

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -232,7 +232,7 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 5,
+            "InjectionIndex": 0,
             "ReturnBehavior": 1,
             "ArgumentBehavior": 4,
             "ArgumentString": "a0, this",
@@ -258,7 +258,7 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 5,
+            "InjectionIndex": 0,
             "ReturnBehavior": 1,
             "ArgumentBehavior": 4,
             "ArgumentString": "a0, this",

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -730,7 +730,7 @@
                 "Network.Connection"
               ]
             },
-            "MSILHash": "EiLHZYTny1lwHboRPMU+JfypHSHyUFw1LwnFB5kSUZw=",
+            "MSILHash": "aQZQPnX03dTDPq/jsEfS82GBz0WrxRO+pbrEETKEn5g=",
             "BaseHookName": null,
             "HookCategory": "Player"
           }
@@ -995,7 +995,7 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 84,
+            "InjectionIndex": 83,
             "ReturnBehavior": 0,
             "ArgumentBehavior": 4,
             "ArgumentString": "this, a0.player",
@@ -1013,7 +1013,7 @@
                 "BaseEntity/RPCMessage"
               ]
             },
-            "MSILHash": "4E1Mzhss6qoSSfMM2j2Bj+6+IgEtmny9cH0vuod+dGE=",
+            "MSILHash": "0Qi4Y8IDRXsHxO2anKj1yEEwyjKEW4EVR8L56DIImMk=",
             "BaseHookName": null,
             "HookCategory": "Structure"
           }
@@ -1021,7 +1021,7 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 57,
+            "InjectionIndex": 56,
             "ReturnBehavior": 0,
             "ArgumentBehavior": 4,
             "ArgumentString": "this, a0.player",
@@ -1039,7 +1039,7 @@
                 "BaseEntity/RPCMessage"
               ]
             },
-            "MSILHash": "6tXxR77bLaVDP6Bm6Hfza/7b1wav0iXbwKFGnz6wKJk=",
+            "MSILHash": "awwPqDilQmvBtART+c6WvxGssuls8JLlxY7WHWn07Lc=",
             "BaseHookName": null,
             "HookCategory": "Structure"
           }
@@ -1649,7 +1649,7 @@
             "HookName": "OnItemRepair",
             "AssemblyName": "Assembly-CSharp.dll",
             "TypeName": "RepairBench",
-            "Flagged": false,
+            "Flagged": true,
             "Signature": {
               "Exposure": 2,
               "Name": "RepairItem",
@@ -2271,7 +2271,7 @@
               "ReturnType": "System.Void",
               "Parameters": []
             },
-            "MSILHash": "Gwcigyqi8KojpaEITmLUqvCOG6cIYKrlpCiFQW4zhzg=",
+            "MSILHash": "dQnhRUfe7lIh+7JhsTWAFkBFGZ+uaJLnVFnwBKIfLtI=",
             "BaseHookName": null,
             "HookCategory": "_Patches"
           }
@@ -2675,7 +2675,7 @@
                 "Network.Message"
               ]
             },
-            "MSILHash": "nBGxMTsNVVS85d3fANgaUcUIXTucbkMHpAEwUsrbr3k=",
+            "MSILHash": "/K8LF87g+qm+Muko2fmVBKBp9RQmfGSCbtWTkKCoscU=",
             "BaseHookName": null,
             "HookCategory": "Player"
           }
@@ -2702,7 +2702,7 @@
                 "System.Boolean"
               ]
             },
-            "MSILHash": "tnv0JcuUOBjDMHD0nmXf5Fe1+SwSM6CCzYc03tgwuiY=",
+            "MSILHash": "PoqqZGv74vAvQo8UewLryVgaedO9gK0X3AzcyRMbntY=",
             "BaseHookName": null,
             "HookCategory": "Server"
           }
@@ -2779,7 +2779,7 @@
                 "System.Boolean"
               ]
             },
-            "MSILHash": "tnv0JcuUOBjDMHD0nmXf5Fe1+SwSM6CCzYc03tgwuiY=",
+            "MSILHash": "PoqqZGv74vAvQo8UewLryVgaedO9gK0X3AzcyRMbntY=",
             "BaseHookName": "OnNewSave",
             "HookCategory": "Server"
           }
@@ -6237,7 +6237,7 @@
               "ReturnType": "System.Void",
               "Parameters": []
             },
-            "MSILHash": "RXQ5sU5SRO9OvkLLnYnZ21hAPLOmsSMAsNPdIAOG1Yc=",
+            "MSILHash": "9l5aDwEcoEfqRQ5LEUzsMp3/p2WtjucAtgt/L3yIrqo=",
             "BaseHookName": null,
             "HookCategory": "Entity"
           }
@@ -6657,7 +6657,7 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 128,
+            "InjectionIndex": 133,
             "ReturnBehavior": 0,
             "ArgumentBehavior": 4,
             "ArgumentString": "this, l8",
@@ -6666,14 +6666,14 @@
             "HookName": "OnFlameThrowerBurn",
             "AssemblyName": "Assembly-CSharp.dll",
             "TypeName": "FlameThrower",
-            "Flagged": false,
+            "Flagged": true,
             "Signature": {
               "Exposure": 2,
               "Name": "FlameTick",
               "ReturnType": "System.Void",
               "Parameters": []
             },
-            "MSILHash": "T3bdWLqS/KACwY+ARxlEKOxmZrmPJo3GpiyaLusOChk=",
+            "MSILHash": "fxQJavxOM8Va4MQCdBmEKC+fnUZb7xBualsmqZe6nh4=",
             "BaseHookName": null,
             "HookCategory": "Weapon"
           }
@@ -6716,7 +6716,7 @@
             "HookName": "OnFireBallDamage",
             "AssemblyName": "Assembly-CSharp.dll",
             "TypeName": "FireBall",
-            "Flagged": false,
+            "Flagged": true,
             "Signature": {
               "Exposure": 2,
               "Name": "DoRadialDamage",
@@ -6740,7 +6740,7 @@
             "HookName": "OnFireBallSpread",
             "AssemblyName": "Assembly-CSharp.dll",
             "TypeName": "FireBall",
-            "Flagged": false,
+            "Flagged": true,
             "Signature": {
               "Exposure": 2,
               "Name": "TryToSpread",
@@ -7340,31 +7340,6 @@
             "MSILHash": "hFFi4tEef/LRIwY7iX2DmEhdq9BiM/Dran5rkhjNskk=",
             "BaseHookName": null,
             "HookCategory": "Player"
-          }
-        },
-        {
-          "Type": "Modify",
-          "Hook": {
-            "InjectionIndex": 126,
-            "RemoveCount": 24,
-            "Instructions": [],
-            "HookTypeName": "Modify",
-            "Name": "FixVanillaChatOnLinux [patch]",
-            "HookName": "FixVanillaChatOnLinux [patch]",
-            "AssemblyName": "Assembly-CSharp.dll",
-            "TypeName": "ConVar.Chat",
-            "Flagged": false,
-            "Signature": {
-              "Exposure": 2,
-              "Name": "say",
-              "ReturnType": "System.Void",
-              "Parameters": [
-                "ConsoleSystem/Arg"
-              ]
-            },
-            "MSILHash": "eYFQZ4ZKL4A5hZLcaMhpg5sKhIneJTCzjX+uR4k17tI=",
-            "BaseHookName": "IOnPlayerChat [internal]",
-            "HookCategory": "_Patches"
           }
         },
         {

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -730,7 +730,7 @@
                 "Network.Connection"
               ]
             },
-            "MSILHash": "CLVm3l9dDmKTKjBg5oCOgoQ7L6wVil2vnkgJqB6OdwY=",
+            "MSILHash": "MiNENunLRnFAAuvFzFm+p+o+ABgzohUy9CYuAIivq60=",
             "BaseHookName": null,
             "HookCategory": "Player"
           }
@@ -2245,7 +2245,7 @@
               "ReturnType": "System.Void",
               "Parameters": []
             },
-            "MSILHash": "3Hb2wI371ob2C39yx64OrrEUjJKfOBZCqELiESUsxkQ=",
+            "MSILHash": "xVLkwdlwLfYSanUok51cbf/EVDranr/ZHV93mQw12RI=",
             "BaseHookName": null,
             "HookCategory": "_Patches"
           }
@@ -2649,7 +2649,7 @@
                 "Network.Message"
               ]
             },
-            "MSILHash": "IoH41udXxx8MM/4Ax+9sgERAeLWcE9Wj0JgAw550fqc=",
+            "MSILHash": "LISNFM/Zx2cV53mXVgbhqrDXm9pZt6WjuurrRdRvXgw=",
             "BaseHookName": null,
             "HookCategory": "Player"
           }
@@ -3228,7 +3228,7 @@
                 "Item"
               ]
             },
-            "MSILHash": "/8X9ZlwQSrtj5a2OUYdVFUx5PstAwQAeIwnJ+zvOKkE=",
+            "MSILHash": "kEoNyXsZ/Oy734P39m4DcrM7hzp9HDbAg9745ESVuVw=",
             "BaseHookName": null,
             "HookCategory": "Item"
           }

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -3086,7 +3086,7 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 9,
+            "InjectionIndex": 4,
             "ReturnBehavior": 1,
             "ArgumentBehavior": 4,
             "ArgumentString": "this, a0.player",
@@ -6132,7 +6132,7 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 344,
+            "InjectionIndex": 345,
             "ReturnBehavior": 1,
             "ArgumentBehavior": 4,
             "ArgumentString": "this, this.AiContext.AIAgent.AttackTarget",
@@ -7130,7 +7130,7 @@
             "HookName": "OnNpcPlayerTarget",
             "AssemblyName": "Assembly-CSharp.dll",
             "TypeName": "NPCPlayerApex",
-            "Flagged": true,
+            "Flagged": false,
             "Signature": {
               "Exposure": 2,
               "Name": "UpdateTargetMemory",

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -1,6 +1,6 @@
 {
   "Name": "Rust",
-  "TargetDirectory": "D:\\Servers\\Rust\\RustDedicated_Data\\Managed",
+  "TargetDirectory": "D:\\Servers\\Rust-staging\\RustDedicated_Data\\Managed",
   "Manifests": [
     {
       "AssemblyName": "Assembly-CSharp.dll",
@@ -730,7 +730,7 @@
                 "Network.Connection"
               ]
             },
-            "MSILHash": "MiNENunLRnFAAuvFzFm+p+o+ABgzohUy9CYuAIivq60=",
+            "MSILHash": "2t/J26dIeMSaQxZFzhVh2PCar5XjBL+zw7Qt68LH7Qc=",
             "BaseHookName": null,
             "HookCategory": "Player"
           }
@@ -2245,7 +2245,7 @@
               "ReturnType": "System.Void",
               "Parameters": []
             },
-            "MSILHash": "xVLkwdlwLfYSanUok51cbf/EVDranr/ZHV93mQw12RI=",
+            "MSILHash": "U4e8rfIXzHnWxRnW8mTp3IXv4UL+jc8SJIx0kNDaVmU=",
             "BaseHookName": null,
             "HookCategory": "_Patches"
           }
@@ -2649,7 +2649,7 @@
                 "Network.Message"
               ]
             },
-            "MSILHash": "LISNFM/Zx2cV53mXVgbhqrDXm9pZt6WjuurrRdRvXgw=",
+            "MSILHash": "HWYanqpQTLCBnF2ejygrxciuRAvHX/qBEtXb20brd04=",
             "BaseHookName": null,
             "HookCategory": "Player"
           }
@@ -2676,7 +2676,7 @@
                 "System.Boolean"
               ]
             },
-            "MSILHash": "tOtlb53xTDaMxUl+HBde0Ursomf6O7L4d9u2UdFgIRU=",
+            "MSILHash": "CfrnPiioH3iVea1CijtHAedIVb+CcNPHbmsJSyjrSLU=",
             "BaseHookName": null,
             "HookCategory": "Server"
           }
@@ -2727,7 +2727,7 @@
                 "System.Boolean"
               ]
             },
-            "MSILHash": "tOtlb53xTDaMxUl+HBde0Ursomf6O7L4d9u2UdFgIRU=",
+            "MSILHash": "CfrnPiioH3iVea1CijtHAedIVb+CcNPHbmsJSyjrSLU=",
             "BaseHookName": "OnNewSave",
             "HookCategory": "Server"
           }

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -2431,7 +2431,7 @@
                 "Item"
               ]
             },
-            "MSILHash": "rLJKbVp70JjUTUfNrML37oxakzhTvt3O9ImpgYTjhvY=",
+            "MSILHash": "KPzLKIxbmMW8fG4OG4FAmf9LSmqOJPxSWsjJCbiQX1M=",
             "BaseHookName": null,
             "HookCategory": "Weapon"
           }
@@ -5524,7 +5524,7 @@
                 "Item"
               ]
             },
-            "MSILHash": "rLJKbVp70JjUTUfNrML37oxakzhTvt3O9ImpgYTjhvY=",
+            "MSILHash": "KPzLKIxbmMW8fG4OG4FAmf9LSmqOJPxSWsjJCbiQX1M=",
             "BaseHookName": "CanCreateWorldProjectile",
             "HookCategory": "Weapon"
           }
@@ -6285,7 +6285,7 @@
               "ReturnType": "System.Void",
               "Parameters": []
             },
-            "MSILHash": "k6b4SLIrgo+NPSb+dvkqJgV4MfFEjsxmnFOXq3lIwY8=",
+            "MSILHash": "nINFsRSYIH4lILvSVZBPOkxq3nPCxDIGuKFykNeKioE=",
             "BaseHookName": null,
             "HookCategory": "Entity"
           }


### PR DESCRIPTION
It is executed immediately after filling in the currentTarget variable in the TargetScan method.
This is a shit attempt to create an analogue of the CanBeTargeted hook for SamSite.
It is more correct to call a hook in the search target, but at the moment it is not possible because of a bug in OxidePatcher.