### PR TITLE
Hooks for VendingMachine

### DIFF
--- a/Steam.ps1
+++ b/Steam.ps1
@@ -21,11 +21,11 @@ $root_dir = $PSScriptRoot
 $tools_dir = "$root_dir\tools"
 $project_dir = "$root_dir\src"
 $deps_dir = "$project_dir\Dependencies"
-$patch_dir = "$deps_dir\Patched"
+$patch_dir = "$deps_dir\Patched\$branch"
 $managed_dir = "$patch_dir\$managed"
 New-Item "$tools_dir", "$managed_dir" -ItemType Directory -Force | Out-Null
 
-# Set name for Oxide patcher file (.opj)
+# Set name for patcher file (.opj)
 if ("$branch" -ne "public" -and (Test-Path "$root_dir\resources\$game_name-$branch.opj")) {
     $opj_name = "$root_dir\resources\$game_name-$branch.opj"
 } else {
@@ -61,7 +61,7 @@ function Find-Dependencies {
         Write-Host "Getting references for $branch branch of $appid"
         try {
             # TODO: Exclude dependencies included in repository
-            $hint_path = "Dependencies\\Patched\\\$\(ManagedDir\)\\"
+            $hint_path = "Dependencies\\Patched\\\$\(SteamBranch\)\\\$\(ManagedDir\)\\"
             ($xml.selectNodes("//Reference") | Select-Object HintPath -ExpandProperty HintPath | Select-String -Pattern "Oxide" -NotMatch) -Replace $hint_path | Out-File "$tools_dir\.references"
         } catch {
             Write-Host "Could not get references or none found in $project.csproj"
@@ -83,7 +83,7 @@ function Get-Downloader {
         # Get latest release info for DepotDownloader
         Write-Host "Determining latest release of DepotDownloader"
         try {
-            $json = (Invoke-WebRequest "https://api.github.com/repos/SteamRE/DepotDownloader/releases" | ConvertFrom-Json)[0]
+            $json = (Invoke-WebRequest "https://api.github.com/repos/SteamRE/DepotDownloader/releases" -UseBasicParsing | ConvertFrom-Json)[0]
             # TODO: Implement auth/token handling for GitHub API
             $version = $json.tag_name -Replace '\w+(\d+(?:\.\d+)+)', '$1'
             $release_zip = $json.assets[0].name
@@ -147,13 +147,13 @@ function Get-Dependencies {
         }
 
         # Cleanup existing game files, else they aren't always the latest
-        #Remove-Item $managed_dir -Include *.dll, *.exe -Exclude "Oxide.Core.dll" -Verbose –Force
+        Remove-Item $patch_dir -Recurse -Force
 
         # TODO: Check for and compare Steam buildid before downloading again
 
         # Attempt to run DepotDownloader to get game DLLs
         try {
-            $depot_process = Start-Process dotnet -ArgumentList "$tools_dir\DepotDownloader.dll $login -app $appid -branch $branch $depot -dir $patch_dir -filelist $tools_dir\.references" -NoNewWindow -Wait
+            Start-Process dotnet -ArgumentList "$tools_dir\DepotDownloader.dll $login -app $appid -branch $branch $depot -dir $patch_dir -filelist $tools_dir\.references" -NoNewWindow -Wait
         } catch {
             Write-Host "Could not start or complete DepotDownloader process"
             Write-Host $_.Exception.Message
@@ -165,13 +165,11 @@ function Get-Dependencies {
         # TODO: Confirm all dependencies were downloaded (no 0kb files), else stop/retry and error with details
     }
 
-    # TODO: Check Oxide.Core.dll version and update if needed
     # Grab latest Oxide.Core.dll build
     Write-Host "Copying latest build of Oxide.Core.dll for $game_name"
-    #$core_version = Get-ChildItem -Directory $core_path | Where-Object { $_.PSIsContainer } | Sort-Object CreationTime -desc | Select-Object -f 1
     if (!(Test-Path "$tools_dir\Oxide.Core.dll")) {
         try {
-            Copy-Item "$root_dir\packages\oxide.core\*\lib\$dotnet\Oxide.Core.dll" "$tools_dir" -Force
+            Copy-Item "$root_dir\packages\oxide.core\*\lib\net46\Oxide.Core.dll" "$tools_dir" -Force
         } catch {
             Write-Host "Could not copy Oxide.Core.dll to $tools_dir"
             Write-Host $_.Exception.Message
@@ -179,10 +177,10 @@ function Get-Dependencies {
             exit 1
         }
     }
-    Write-Host "Copying latest build of Oxide.Core.dll for OxidePatcher"
+    Write-Host "Copying latest build of Oxide.Core.dll for patcher"
     if (!(Test-Path "$managed_dir\Oxide.Core.dll")) {
         try {
-            Copy-Item "$root_dir\packages\oxide.core\*\lib\$dotnet\Oxide.Core.dll" "$managed_dir" -Force
+            Copy-Item "$root_dir\packages\oxide.core\*\lib\net46\Oxide.Core.dll" "$managed_dir" -Force
         } catch {
             Write-Host "Could not copy Oxide.Core.dll to $managed_dir"
             Write-Host $_.Exception.Message
@@ -260,11 +258,11 @@ function Start-Deobfuscator {
 }
 
 function Get-Patcher {
-    # TODO: MD5 comparision of local OxidePatcher.exe and remote header
-    # Check if OxidePatcher is already downloaded
+    # TODO: MD5 comparison of local OxidePatcher.exe and remote header
+    # Check if patcher is already downloaded
     $patcher_exe = "$tools_dir\OxidePatcher.exe"
     if (!(Test-Path "$patcher_exe") -or (Get-ChildItem "$patcher_exe").CreationTime -lt (Get-Date).AddDays(-7)) {
-        # Download latest Oxide Patcher build
+        # Download latest patcher build
         Write-Host "Downloading latest build of OxidePatcher"
         $patcher_url = "https://github.com/OxideMod/OxidePatcher/releases/download/latest/OxidePatcher.exe"
         try {
@@ -276,14 +274,14 @@ function Get-Patcher {
             exit 1
         }
     } else {
-        Write-Host "Recent build of OxidePatcher already downloaded"
+        Write-Host "Recent build of patcher already downloaded"
     }
 
     Start-Patcher
 }
 
 function Start-Patcher {
-    # Check if we need to get the Oxide patcher
+    # Check if we need to get the patcher
     if (!(Test-Path "$tools_dir\OxidePatcher.exe")) {
         Get-Patcher # TODO: Add infinite loop prevention
         return
@@ -291,11 +289,11 @@ function Start-Patcher {
 
     # TODO: Make sure dependencies exist before trying to patch
 
-    # Attempt to patch game using the Oxide patcher
+    # Attempt to patch game using the patcher
     try {
         Start-Process "$tools_dir\OxidePatcher.exe" -WorkingDirectory "$managed_dir" -ArgumentList "-c -p `"$managed_dir`" $opj_name" -NoNewWindow -Wait
     } catch {
-        Write-Host "Could not start or complete OxidePatcher process"
+        Write-Host "Could not start or complete patcher process"
         Write-Host $_.Exception.Message
         if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
         exit 1

--- a/Steam.ps1
+++ b/Steam.ps1
@@ -167,26 +167,22 @@ function Get-Dependencies {
 
     # Grab latest Oxide.Core.dll build
     Write-Host "Copying latest build of Oxide.Core.dll for $game_name"
-    if (!(Test-Path "$tools_dir\Oxide.Core.dll")) {
-        try {
-            Copy-Item "$root_dir\packages\oxide.core\*\lib\net46\Oxide.Core.dll" "$tools_dir" -Force
-        } catch {
-            Write-Host "Could not copy Oxide.Core.dll to $tools_dir"
-            Write-Host $_.Exception.Message
-            if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
-            exit 1
-        }
+    try {
+        Copy-Item "$root_dir\packages\oxide.core\*\lib\net46\Oxide.Core.dll" "$tools_dir" -Force
+    } catch {
+        Write-Host "Could not copy Oxide.Core.dll to $tools_dir"
+        Write-Host $_.Exception.Message
+        if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
+        exit 1
     }
     Write-Host "Copying latest build of Oxide.Core.dll for patcher"
-    if (!(Test-Path "$managed_dir\Oxide.Core.dll")) {
-        try {
-            Copy-Item "$root_dir\packages\oxide.core\*\lib\net46\Oxide.Core.dll" "$managed_dir" -Force
-        } catch {
-            Write-Host "Could not copy Oxide.Core.dll to $managed_dir"
-            Write-Host $_.Exception.Message
-            if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
-            exit 1
-        }
+    try {
+        Copy-Item "$root_dir\packages\oxide.core\*\lib\net46\Oxide.Core.dll" "$managed_dir" -Force
+    } catch {
+        Write-Host "Could not copy Oxide.Core.dll to $managed_dir"
+        Write-Host $_.Exception.Message
+        if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
+        exit 1
     }
 
     if ($deobf) {

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -4237,7 +4237,7 @@
             "HookName": "OnRecycleItem [patch]",
             "AssemblyName": "Assembly-CSharp.dll",
             "TypeName": "Recycler",
-            "Flagged": false,
+            "Flagged": true,
             "Signature": {
               "Exposure": 2,
               "Name": "RecycleThink",
@@ -6640,7 +6640,7 @@
             "HookName": "OnLootPlayer",
             "AssemblyName": "Assembly-CSharp.dll",
             "TypeName": "BasePlayer",
-            "Flagged": false,
+            "Flagged": true,
             "Signature": {
               "Exposure": 2,
               "Name": "RPC_LootPlayer",

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -3502,7 +3502,7 @@
             "InjectionIndex": 0,
             "ReturnBehavior": 1,
             "ArgumentBehavior": 4,
-            "ArgumentString": "this, msg.player",
+            "ArgumentString": "this, a0.player",
             "HookTypeName": "Simple",
             "Name": "OnRotateVendingMachine",
             "HookName": "OnRotateVendingMachine",

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -659,7 +659,7 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 914,
+            "InjectionIndex": 882,
             "ReturnBehavior": 1,
             "ArgumentBehavior": 4,
             "ArgumentString": "this, l2",
@@ -677,7 +677,7 @@
                 "BaseEntity/RPCMessage"
               ]
             },
-            "MSILHash": "dTHPJ8yGm0AvICFA62667IalZsOwa3oFcLtiU/SwX4g=",
+            "MSILHash": "qGXKLwLB/gUWsggFttswywXh/WrzbdRZhFyxL+nIJHk=",
             "BaseHookName": null,
             "HookCategory": "Player"
           }
@@ -730,7 +730,7 @@
                 "Network.Connection"
               ]
             },
-            "MSILHash": "AIuhaSnlHQ6mJtwpxk6uI5pRRw63rhwFFq9rbHpzF0I=",
+            "MSILHash": "CLVm3l9dDmKTKjBg5oCOgoQ7L6wVil2vnkgJqB6OdwY=",
             "BaseHookName": null,
             "HookCategory": "Player"
           }
@@ -947,7 +947,7 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 42,
+            "InjectionIndex": 45,
             "ReturnBehavior": 0,
             "ArgumentBehavior": 1,
             "ArgumentString": null,
@@ -963,7 +963,7 @@
               "ReturnType": "System.Void",
               "Parameters": []
             },
-            "MSILHash": "fGrwr0li+7FCQzf7MXDaHD7CQwHwKgf20CjXNscG7l0=",
+            "MSILHash": "bxiW0e4r+qZQ/ixgNT/QftCVJRSzzh7ADVKcLb1GVWQ=",
             "BaseHookName": null,
             "HookCategory": "Player"
           }
@@ -1118,7 +1118,7 @@
                 "HitInfo"
               ]
             },
-            "MSILHash": "VKqhOyOsrHfERz4YLIHjMWXvY40DUysN8ByLafoVMYc=",
+            "MSILHash": "WX6FIsPNXoqP3BwX0lFLhMipnNalx2sVm6LBPk+JmCU=",
             "BaseHookName": null,
             "HookCategory": "Player"
           }
@@ -1178,7 +1178,7 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 147,
+            "InjectionIndex": 145,
             "ReturnBehavior": 0,
             "ArgumentBehavior": 4,
             "ArgumentString": "a0, l1",
@@ -1196,7 +1196,7 @@
                 "ItemCraftTask"
               ]
             },
-            "MSILHash": "kH0usIlPDBORJez4kW8ogE3lOG19qhsmPNfzW7ABTBw=",
+            "MSILHash": "xwlleEv8IUHTVSIQqSOiTdxVfq9ScYhw+50sR0smbO8=",
             "BaseHookName": null,
             "HookCategory": "Item"
           }
@@ -1358,7 +1358,7 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 216,
+            "InjectionIndex": 223,
             "ReturnBehavior": 0,
             "ArgumentBehavior": 4,
             "ArgumentString": "l0, l8",
@@ -1376,7 +1376,7 @@
                 "BaseEntity/RPCMessage"
               ]
             },
-            "MSILHash": "Vo5MLFd5RwGCN1zlf/qlKpnyRGLQ7boYqWyGkz8PPFY=",
+            "MSILHash": "PeDugO4Bi8+n8jSHOZSgZaegDPtNPcScGdPovPBI2Uk=",
             "BaseHookName": null,
             "HookCategory": "Weapon"
           }
@@ -1402,7 +1402,7 @@
                 "BaseEntity/RPCMessage"
               ]
             },
-            "MSILHash": "jpGESaKn1vRV3thiPBWV9ui9yPOATuWiS5s0FZn9sYA=",
+            "MSILHash": "dgd8sk6vRuXiAJxEDxeodx6IX5STFA7zGMjTHccR/As=",
             "BaseHookName": null,
             "HookCategory": "Weapon"
           }
@@ -1504,7 +1504,7 @@
             },
             "MSILHash": "U8X0WIP/tTq33l+6Ke/on8yYnKW31iymfql4eT+OQaw=",
             "BaseHookName": null,
-            "HookCategory": "Resource"
+            "HookCategory": "__Broken__"
           }
         },
         {
@@ -1660,7 +1660,7 @@
             },
             "MSILHash": "DahR9iHXV/BZN7dY+tt5T4UjEhZSYaIj6KpFcsKMNNg=",
             "BaseHookName": null,
-            "HookCategory": "Item"
+            "HookCategory": "__Broken__"
           }
         },
         {
@@ -2059,32 +2059,6 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 20,
-            "ReturnBehavior": 1,
-            "ArgumentBehavior": 4,
-            "ArgumentString": "this, l1",
-            "HookTypeName": "Simple",
-            "Name": "OnPlayerLand",
-            "HookName": "OnPlayerLand",
-            "AssemblyName": "Assembly-CSharp.dll",
-            "TypeName": "BasePlayer",
-            "Flagged": false,
-            "Signature": {
-              "Exposure": 0,
-              "Name": "OnPlayerLanded",
-              "ReturnType": "System.Void",
-              "Parameters": [
-                "BaseEntity/RPCMessage"
-              ]
-            },
-            "MSILHash": "WfjFSqcstSVzMjihJYdW2sRQN5zmHV5zScigKY384MI=",
-            "BaseHookName": null,
-            "HookCategory": "Player"
-          }
-        },
-        {
-          "Type": "Simple",
-          "Hook": {
             "InjectionIndex": 0,
             "ReturnBehavior": 1,
             "ArgumentBehavior": 3,
@@ -2271,7 +2245,7 @@
               "ReturnType": "System.Void",
               "Parameters": []
             },
-            "MSILHash": "+5o9fm5e/nUb1WmLWXOPSCAI0ouBoIKx4r5FvgWWTtc=",
+            "MSILHash": "3Hb2wI371ob2C39yx64OrrEUjJKfOBZCqELiESUsxkQ=",
             "BaseHookName": null,
             "HookCategory": "_Patches"
           }
@@ -2431,7 +2405,7 @@
                 "Item"
               ]
             },
-            "MSILHash": "KPzLKIxbmMW8fG4OG4FAmf9LSmqOJPxSWsjJCbiQX1M=",
+            "MSILHash": "rLJKbVp70JjUTUfNrML37oxakzhTvt3O9ImpgYTjhvY=",
             "BaseHookName": null,
             "HookCategory": "Weapon"
           }
@@ -2591,7 +2565,7 @@
                 "System.UInt64"
               ]
             },
-            "MSILHash": "DiLxz3x+/hHtHIXM4lBalav0FH5b8j+vm6MLYVEYBsc=",
+            "MSILHash": "fLHHmyr0IjE9z1nG/ijHOnJuK7XH8BjB2GfKyEJ3xiY=",
             "BaseHookName": null,
             "HookCategory": "Server"
           }
@@ -2675,7 +2649,7 @@
                 "Network.Message"
               ]
             },
-            "MSILHash": "M1lFVmiCqwsaU6ncuj2YUbsGweWdOAGG7gpTax7lRr4=",
+            "MSILHash": "IoH41udXxx8MM/4Ax+9sgERAeLWcE9Wj0JgAw550fqc=",
             "BaseHookName": null,
             "HookCategory": "Player"
           }
@@ -2702,35 +2676,9 @@
                 "System.Boolean"
               ]
             },
-            "MSILHash": "PoqqZGv74vAvQo8UewLryVgaedO9gK0X3AzcyRMbntY=",
+            "MSILHash": "tOtlb53xTDaMxUl+HBde0Ursomf6O7L4d9u2UdFgIRU=",
             "BaseHookName": null,
             "HookCategory": "Server"
-          }
-        },
-        {
-          "Type": "Simple",
-          "Hook": {
-            "InjectionIndex": 62,
-            "ReturnBehavior": 0,
-            "ArgumentBehavior": 4,
-            "ArgumentString": "this, l1",
-            "HookTypeName": "Simple",
-            "Name": "OnPlayerLanded",
-            "HookName": "OnPlayerLanded",
-            "AssemblyName": "Assembly-CSharp.dll",
-            "TypeName": "BasePlayer",
-            "Flagged": false,
-            "Signature": {
-              "Exposure": 0,
-              "Name": "OnPlayerLanded",
-              "ReturnType": "System.Void",
-              "Parameters": [
-                "BaseEntity/RPCMessage"
-              ]
-            },
-            "MSILHash": "WfjFSqcstSVzMjihJYdW2sRQN5zmHV5zScigKY384MI=",
-            "BaseHookName": "OnPlayerLand",
-            "HookCategory": "Player"
           }
         },
         {
@@ -2779,7 +2727,7 @@
                 "System.Boolean"
               ]
             },
-            "MSILHash": "PoqqZGv74vAvQo8UewLryVgaedO9gK0X3AzcyRMbntY=",
+            "MSILHash": "tOtlb53xTDaMxUl+HBde0Ursomf6O7L4d9u2UdFgIRU=",
             "BaseHookName": "OnNewSave",
             "HookCategory": "Server"
           }
@@ -2803,7 +2751,7 @@
               "ReturnType": "System.Void",
               "Parameters": []
             },
-            "MSILHash": "rbB7PmS1Y3JFMJDug+212WqLj2Boc/bJXwO9YNbQ9sY=",
+            "MSILHash": "j9qavMA2ZAyLO1XGs0JdvUT5PuwetXfPtAxJvSM4+Z0=",
             "BaseHookName": null,
             "HookCategory": "Player"
           }
@@ -2984,7 +2932,7 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 45,
+            "InjectionIndex": 4,
             "ReturnBehavior": 0,
             "ArgumentBehavior": 1,
             "ArgumentString": null,
@@ -3000,7 +2948,7 @@
               "ReturnType": "System.Void",
               "Parameters": []
             },
-            "MSILHash": "UAt7R+IW8fUEhrTEuChH8QuQW/QnVCmdOas8PSvTwn8=",
+            "MSILHash": "bVFkTfwmGLriwUJn8Z86aVsL87atobRoCWhCZe09Jv0=",
             "BaseHookName": null,
             "HookCategory": "Player"
           }
@@ -3232,7 +3180,7 @@
             },
             "MSILHash": "QCrsm4a9Cwo8zNG0bzJPfaPf8iKnSEGz/4nV+vAPJ00=",
             "BaseHookName": null,
-            "HookCategory": "Player"
+            "HookCategory": "__Broken__"
           }
         },
         {
@@ -3441,7 +3389,7 @@
             },
             "MSILHash": "wJjvWeKLT/NWi+9XnLA7XJi9m434JmZ71SgQKky4LKg=",
             "BaseHookName": null,
-            "HookCategory": "Vending"
+            "HookCategory": "__Broken__"
           }
         },
         {
@@ -4246,7 +4194,7 @@
             },
             "MSILHash": "wSd4Lwg85uzdoHKZCno+/AZoNhsAk3zCVFaNVUd2tSk=",
             "BaseHookName": "OnRecycleItem",
-            "HookCategory": "_Patches"
+            "HookCategory": "__Broken__"
           }
         },
         {
@@ -4656,7 +4604,7 @@
             },
             "MSILHash": "lCKuiaTWOrkBy5zEgGRWJuIjIGBbRx8BySQex9btYUo=",
             "BaseHookName": null,
-            "HookCategory": "Player"
+            "HookCategory": "__Broken__"
           }
         },
         {
@@ -4728,7 +4676,7 @@
                 "BaseEntity/RPCMessage"
               ]
             },
-            "MSILHash": "cu36huukvp+w0JRhHm6IEKTFNVjz+bOACjyyUZR8Ns4=",
+            "MSILHash": "wQ+ICwpAOHN8oVNXdjbu4UVpcxDJ3PEu2WywdfQ5nMk=",
             "BaseHookName": null,
             "HookCategory": "Weapon"
           }
@@ -4750,9 +4698,11 @@
               "Exposure": 1,
               "Name": "ReloadMagazine",
               "ReturnType": "System.Void",
-              "Parameters": []
+              "Parameters": [
+                "System.Int32"
+              ]
             },
-            "MSILHash": "leemnH9bjSC3S+9e9r8WF+x0+b2hB4S79sErdHO7Y/s=",
+            "MSILHash": "J85QCub4di16mJl1Oca8ibEGl4fvf9hKx3rmcDo+Ebk=",
             "BaseHookName": null,
             "HookCategory": "Weapon"
           }
@@ -5316,7 +5266,7 @@
             },
             "MSILHash": "wJjvWeKLT/NWi+9XnLA7XJi9m434JmZ71SgQKky4LKg=",
             "BaseHookName": "OnRefreshVendingStock [blueprint]",
-            "HookCategory": "Vending"
+            "HookCategory": "__Broken__"
           }
         },
         {
@@ -5524,7 +5474,7 @@
                 "Item"
               ]
             },
-            "MSILHash": "KPzLKIxbmMW8fG4OG4FAmf9LSmqOJPxSWsjJCbiQX1M=",
+            "MSILHash": "rLJKbVp70JjUTUfNrML37oxakzhTvt3O9ImpgYTjhvY=",
             "BaseHookName": "CanCreateWorldProjectile",
             "HookCategory": "Weapon"
           }
@@ -5648,7 +5598,7 @@
             },
             "MSILHash": "QCrsm4a9Cwo8zNG0bzJPfaPf8iKnSEGz/4nV+vAPJ00=",
             "BaseHookName": "CanBeTargeted [flameturret]",
-            "HookCategory": "_Patches"
+            "HookCategory": "__Broken__"
           }
         },
         {
@@ -5692,7 +5642,7 @@
             },
             "MSILHash": "lCKuiaTWOrkBy5zEgGRWJuIjIGBbRx8BySQex9btYUo=",
             "BaseHookName": "CanBeTargeted [guntrap]",
-            "HookCategory": "_Patches"
+            "HookCategory": "__Broken__"
           }
         },
         {
@@ -6150,7 +6100,7 @@
             },
             "MSILHash": "Y4TCpueeO8M72L7n6CQlAhdcK2OXdZRdTJH27jC3e98=",
             "BaseHookName": null,
-            "HookCategory": "Entity"
+            "HookCategory": "__Broken__"
           }
         },
         {
@@ -6285,7 +6235,7 @@
               "ReturnType": "System.Void",
               "Parameters": []
             },
-            "MSILHash": "nINFsRSYIH4lILvSVZBPOkxq3nPCxDIGuKFykNeKioE=",
+            "MSILHash": "k6b4SLIrgo+NPSb+dvkqJgV4MfFEjsxmnFOXq3lIwY8=",
             "BaseHookName": null,
             "HookCategory": "Entity"
           }
@@ -6651,7 +6601,7 @@
             },
             "MSILHash": "PuQPoN4go462lXs+1P6tk4GvthDirt0vwV+UfGqXvFw=",
             "BaseHookName": null,
-            "HookCategory": "Player"
+            "HookCategory": "__Broken__"
           }
         },
         {
@@ -6675,7 +6625,7 @@
             },
             "MSILHash": "fxQJavxOM8Va4MQCdBmEKC+fnUZb7xBualsmqZe6nh4=",
             "BaseHookName": null,
-            "HookCategory": "Weapon"
+            "HookCategory": "__Broken__"
           }
         },
         {
@@ -6686,7 +6636,7 @@
             "ArgumentBehavior": 4,
             "ArgumentString": "this, l1",
             "HookTypeName": "Simple",
-            "Name": "OnFlameExplosion",
+            "Name": "OnFlameExplosion [broken]",
             "HookName": "OnFlameExplosion",
             "AssemblyName": "Assembly-CSharp.dll",
             "TypeName": "FlameExplosive",
@@ -6701,7 +6651,7 @@
             },
             "MSILHash": "8rr2VSawA+BBAqENFQ72qgYUQCfevQxQ3KtL2lQJCA8=",
             "BaseHookName": null,
-            "HookCategory": "Entity"
+            "HookCategory": "__Broken__"
           }
         },
         {
@@ -6725,7 +6675,7 @@
             },
             "MSILHash": "kbfuDpDzAXyYQYSlO3scgP1MVAb2h3jpu5lo4Y6bxCw=",
             "BaseHookName": null,
-            "HookCategory": "Entity"
+            "HookCategory": "__Broken__"
           }
         },
         {
@@ -6749,7 +6699,7 @@
             },
             "MSILHash": "WAdUho0ZGAAf8N4EQggkN98zjxMm5A4D1XGbTMh8ubc=",
             "BaseHookName": null,
-            "HookCategory": "Entity"
+            "HookCategory": "__Broken__"
           }
         },
         {
@@ -6800,7 +6750,7 @@
                 "ConsoleSystem/Arg"
               ]
             },
-            "MSILHash": "eYFQZ4ZKL4A5hZLcaMhpg5sKhIneJTCzjX+uR4k17tI=",
+            "MSILHash": "f7/u9kweTwkUqh3IskKPD37BAec7fXJVAP9ToRL4/p0=",
             "BaseHookName": null,
             "HookCategory": "Player"
           }
@@ -6826,7 +6776,7 @@
                 "ConsoleSystem/Arg"
               ]
             },
-            "MSILHash": "eYFQZ4ZKL4A5hZLcaMhpg5sKhIneJTCzjX+uR4k17tI=",
+            "MSILHash": "f7/u9kweTwkUqh3IskKPD37BAec7fXJVAP9ToRL4/p0=",
             "BaseHookName": "IOnPlayerCommand [internal]",
             "HookCategory": "Player"
           }
@@ -7144,7 +7094,7 @@
             },
             "MSILHash": "/nEuvnw+JQmAu0tQUMVatcE+LV/V32o2o2HJf3ec34Q=",
             "BaseHookName": null,
-            "HookCategory": "Entity"
+            "HookCategory": "__Broken__"
           }
         },
         {
@@ -7215,7 +7165,7 @@
             "ArgumentBehavior": 4,
             "ArgumentString": "this, a0",
             "HookTypeName": "Simple",
-            "Name": "OnNpcPlayerTarget [animals]",
+            "Name": "OnNpcPlayerTarget [animals, broken]",
             "HookName": "OnNpcPlayerTarget",
             "AssemblyName": "Assembly-CSharp.dll",
             "TypeName": "Rust.Ai.HTN.BaseNpcMemory",
@@ -7285,7 +7235,7 @@
             },
             "MSILHash": "66fWKhBmLgHOrluqq5bQWpxJ3AcyX52NU+Ljdfl0c+o=",
             "BaseHookName": null,
-            "HookCategory": "Entity"
+            "HookCategory": "__Broken__"
           }
         },
         {
@@ -7313,7 +7263,7 @@
             },
             "MSILHash": "M5QSAh4W32SQcwq/dndv+Npto1ZYMIZyBV2cpzq/7P4=",
             "BaseHookName": null,
-            "HookCategory": "Entity"
+            "HookCategory": "__Broken__"
           }
         },
         {
@@ -7573,7 +7523,7 @@
             },
             "MSILHash": "NB7aDVxtM6Pcx0xoSjNUxhgjfYs84oTSJYQcqFpoyf0=",
             "BaseHookName": "OnTeamCreate",
-            "HookCategory": "Team"
+            "HookCategory": "__Broken__"
           }
         },
         {
@@ -7925,6 +7875,58 @@
             "MSILHash": "N+8KQI012/z3UtI6P6EAkadxLBonXARkWwOF5gQXzu8=",
             "BaseHookName": null,
             "HookCategory": "_Patches"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 9,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, l0",
+            "HookTypeName": "Simple",
+            "Name": "OnPlayerLand",
+            "HookName": "OnPlayerLand",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "BasePlayer",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "ApplyFallDamageFromVelocity",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "System.Single"
+              ]
+            },
+            "MSILHash": "XAbBUjv9aYi01AmWlvIJ98FqWYe3fbF070HqXQjRTuM=",
+            "BaseHookName": null,
+            "HookCategory": "Player"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 51,
+            "ReturnBehavior": 0,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, l0",
+            "HookTypeName": "Simple",
+            "Name": "OnPlayerLanded",
+            "HookName": "OnPlayerLanded",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "BasePlayer",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "ApplyFallDamageFromVelocity",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "System.Single"
+              ]
+            },
+            "MSILHash": "XAbBUjv9aYi01AmWlvIJ98FqWYe3fbF070HqXQjRTuM=",
+            "BaseHookName": "OnPlayerLand",
+            "HookCategory": "Player"
           }
         }
       ],

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -1649,7 +1649,7 @@
             "HookName": "OnItemRepair",
             "AssemblyName": "Assembly-CSharp.dll",
             "TypeName": "RepairBench",
-            "Flagged": true,
+            "Flagged": false,
             "Signature": {
               "Exposure": 2,
               "Name": "RepairItem",
@@ -6141,7 +6141,7 @@
             "HookName": "IOnNpcTarget",
             "AssemblyName": "Assembly-CSharp.dll",
             "TypeName": "BaseNpc",
-            "Flagged": true,
+            "Flagged": false,
             "Signature": {
               "Exposure": 0,
               "Name": "AggroClosestEnemy",
@@ -6584,7 +6584,7 @@
             "HookName": "ItemMaxStackableMove [patch]",
             "AssemblyName": "Assembly-CSharp.dll",
             "TypeName": "PlayerInventory",
-            "Flagged": true,
+            "Flagged": false,
             "Signature": {
               "Exposure": 0,
               "Name": "MoveItem",
@@ -6640,7 +6640,7 @@
             "HookName": "OnLootPlayer",
             "AssemblyName": "Assembly-CSharp.dll",
             "TypeName": "BasePlayer",
-            "Flagged": true,
+            "Flagged": false,
             "Signature": {
               "Exposure": 2,
               "Name": "RPC_LootPlayer",
@@ -6666,7 +6666,7 @@
             "HookName": "OnFlameThrowerBurn",
             "AssemblyName": "Assembly-CSharp.dll",
             "TypeName": "FlameThrower",
-            "Flagged": true,
+            "Flagged": false,
             "Signature": {
               "Exposure": 2,
               "Name": "FlameTick",
@@ -6690,7 +6690,7 @@
             "HookName": "OnFlameExplosion",
             "AssemblyName": "Assembly-CSharp.dll",
             "TypeName": "FlameExplosive",
-            "Flagged": true,
+            "Flagged": false,
             "Signature": {
               "Exposure": 2,
               "Name": "Explode",
@@ -6716,7 +6716,7 @@
             "HookName": "OnFireBallDamage",
             "AssemblyName": "Assembly-CSharp.dll",
             "TypeName": "FireBall",
-            "Flagged": true,
+            "Flagged": false,
             "Signature": {
               "Exposure": 2,
               "Name": "DoRadialDamage",
@@ -6740,7 +6740,7 @@
             "HookName": "OnFireBallSpread",
             "AssemblyName": "Assembly-CSharp.dll",
             "TypeName": "FireBall",
-            "Flagged": true,
+            "Flagged": false,
             "Signature": {
               "Exposure": 2,
               "Name": "TryToSpread",
@@ -6843,7 +6843,7 @@
             "HookName": "OnNpcPlayerResume",
             "AssemblyName": "Assembly-CSharp.dll",
             "TypeName": "NPCPlayerApex",
-            "Flagged": true,
+            "Flagged": false,
             "Signature": {
               "Exposure": 2,
               "Name": "Resume",

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -11103,6 +11103,63 @@
             "Parameters": []
           },
           "MSILHash": ""
+        },
+        {
+          "Name": "SamSite::lockOnTime",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "SamSite",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "lockOnTime",
+            "FullTypeName": "System.Single SamSite::lockOnTime",
+            "Parameters": []
+          },
+          "MSILHash": ""
+        },
+        {
+          "Name": "SamSite::lastTargetVisibleTime",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "SamSite",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "lastTargetVisibleTime",
+            "FullTypeName": "System.Single SamSite::lastTargetVisibleTime",
+            "Parameters": []
+          },
+          "MSILHash": ""
+        },
+        {
+          "Name": "SamSite::nextBurstTime",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "SamSite",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "nextBurstTime",
+            "FullTypeName": "System.Single SamSite::nextBurstTime",
+            "Parameters": []
+          },
+          "MSILHash": ""
         }
       ],
       "Fields": [

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -1,6 +1,6 @@
 {
   "Name": "Rust",
-  "TargetDirectory": "D:\\Servers\\Rust-staging\\RustDedicated_Data\\Managed",
+  "TargetDirectory": "D:\\Servers\\Rust\\RustDedicated_Data\\Managed",
   "Manifests": [
     {
       "AssemblyName": "Assembly-CSharp.dll",

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -11160,6 +11160,25 @@
             "Parameters": []
           },
           "MSILHash": ""
+        },
+        {
+          "Name": "BasePlayer::firedProjectiles",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "BasePlayer",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "firedProjectiles",
+            "FullTypeName": "System.Collections.Generic.Dictionary`2<System.Int32,BasePlayer/FiredProjectile> BasePlayer::firedProjectiles",
+            "Parameters": []
+          },
+          "MSILHash": ""
         }
       ],
       "Fields": [

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -3603,7 +3603,7 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 0,
+            "InjectionIndex": 16,
             "ReturnBehavior": 0,
             "ArgumentBehavior": 2,
             "ArgumentString": null,
@@ -4890,7 +4890,7 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 0,
+            "InjectionIndex": 5,
             "ReturnBehavior": 0,
             "ArgumentBehavior": 2,
             "ArgumentString": null,

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -7961,7 +7961,7 @@
             "InjectionIndex": 21,
             "ReturnBehavior": 1,
             "ArgumentBehavior": 4,
-            "ArgumentString": "a0.player, l0",
+            "ArgumentString": "a0.player, l0, l2",
             "HookTypeName": "Simple",
             "Name": "CanDeployItem",
             "HookName": "CanDeployItem",

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -7961,7 +7961,7 @@
             "InjectionIndex": 21,
             "ReturnBehavior": 1,
             "ArgumentBehavior": 4,
-            "ArgumentString": "a0.player, l0, l2",
+            "ArgumentString": "a0.player, this, l2",
             "HookTypeName": "Simple",
             "Name": "CanDeployItem",
             "HookName": "CanDeployItem",

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -7619,7 +7619,7 @@
                 "Operand": "mscorlib|System.OperatingSystem|get_Platform"
               },
               {
-                "OpCode": "ldc_i4_2",
+                "OpCode": "ldc_i4_4",
                 "OpType": "None",
                 "Operand": null
               },
@@ -7629,7 +7629,7 @@
                 "Operand": null
               },
               {
-                "OpCode": "brfalse",
+                "OpCode": "brtrue",
                 "OpType": "Instruction",
                 "Operand": 29
               }
@@ -7668,7 +7668,7 @@
                 "Operand": "mscorlib|System.OperatingSystem|get_Platform"
               },
               {
-                "OpCode": "ldc_i4_2",
+                "OpCode": "ldc_i4_4",
                 "OpType": "None",
                 "Operand": null
               },
@@ -7678,7 +7678,7 @@
                 "Operand": null
               },
               {
-                "OpCode": "brfalse",
+                "OpCode": "brtrue",
                 "OpType": "Instruction",
                 "Operand": 69
               }
@@ -7721,7 +7721,7 @@
                 "Operand": "mscorlib|System.OperatingSystem|get_Platform"
               },
               {
-                "OpCode": "ldc_i4_2",
+                "OpCode": "ldc_i4_4",
                 "OpType": "None",
                 "Operand": null
               },
@@ -7731,7 +7731,7 @@
                 "Operand": null
               },
               {
-                "OpCode": "brfalse",
+                "OpCode": "brtrue",
                 "OpType": "Instruction",
                 "Operand": 13
               }
@@ -7770,7 +7770,7 @@
                 "Operand": "mscorlib|System.OperatingSystem|get_Platform"
               },
               {
-                "OpCode": "ldc_i4_2",
+                "OpCode": "ldc_i4_4",
                 "OpType": "None",
                 "Operand": null
               },
@@ -7780,7 +7780,7 @@
                 "Operand": null
               },
               {
-                "OpCode": "brfalse",
+                "OpCode": "brtrue",
                 "OpType": "Instruction",
                 "Operand": 49
               }
@@ -7821,7 +7821,7 @@
                 "Operand": "mscorlib|System.OperatingSystem|get_Platform"
               },
               {
-                "OpCode": "ldc_i4_2",
+                "OpCode": "ldc_i4_4",
                 "OpType": "None",
                 "Operand": null
               },
@@ -7831,7 +7831,7 @@
                 "Operand": null
               },
               {
-                "OpCode": "brfalse",
+                "OpCode": "brtrue",
                 "OpType": "Instruction",
                 "Operand": 8
               }
@@ -7870,7 +7870,7 @@
                 "Operand": "mscorlib|System.OperatingSystem|get_Platform"
               },
               {
-                "OpCode": "ldc_i4_2",
+                "OpCode": "ldc_i4_4",
                 "OpType": "None",
                 "Operand": null
               },
@@ -7880,7 +7880,7 @@
                 "Operand": null
               },
               {
-                "OpCode": "brfalse",
+                "OpCode": "brtrue",
                 "OpType": "Instruction",
                 "Operand": 5
               }

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -7343,6 +7343,266 @@
           }
         },
         {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 13,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "l0",
+            "HookTypeName": "Simple",
+            "Name": "OnTeamCreate",
+            "HookName": "OnTeamCreate",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "RelationshipManager",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "trycreateteam",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "ConsoleSystem/Arg"
+              ]
+            },
+            "MSILHash": "NB7aDVxtM6Pcx0xoSjNUxhgjfYs84oTSJYQcqFpoyf0=",
+            "BaseHookName": null,
+            "HookCategory": "Team"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 57,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "l0, l4",
+            "HookTypeName": "Simple",
+            "Name": "OnTeamInvite",
+            "HookName": "OnTeamInvite",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "RelationshipManager",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "sendinvite",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "ConsoleSystem/Arg"
+              ]
+            },
+            "MSILHash": "GXrf9FdZIEjVTK85fSM3b/SpI5s7axqNqryes8EnzbA=",
+            "BaseHookName": null,
+            "HookCategory": "Team"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 27,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "l0, l2",
+            "HookTypeName": "Simple",
+            "Name": "OnTeamRejectInvite",
+            "HookName": "OnTeamRejectInvite",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "RelationshipManager",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "rejectinvite",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "ConsoleSystem/Arg"
+              ]
+            },
+            "MSILHash": "uIbLOC3SlGAlCrFcu0ubw4OEUJ/Tx4wvVvZEAlJsptw=",
+            "BaseHookName": null,
+            "HookCategory": "Team"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 42,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "l2, l1",
+            "HookTypeName": "Simple",
+            "Name": "OnTeamPromote",
+            "HookName": "OnTeamPromote",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "RelationshipManager",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "promote",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "ConsoleSystem/Arg"
+              ]
+            },
+            "MSILHash": "GXlJ4gJv8JbJLBVt0IP+sPnjJ4WbWRZMD/Z0p6umDJQ=",
+            "BaseHookName": null,
+            "HookCategory": "Team"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 19,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "l1, l0",
+            "HookTypeName": "Simple",
+            "Name": "OnTeamLeave",
+            "HookName": "OnTeamLeave",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "RelationshipManager",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "leaveteam",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "ConsoleSystem/Arg"
+              ]
+            },
+            "MSILHash": "z8DXgEwPWd7fXMR7CQdonUOAEAhqmvjuNnNxWiBEPlg=",
+            "BaseHookName": null,
+            "HookCategory": "Team"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 33,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "l1, l0",
+            "HookTypeName": "Simple",
+            "Name": "OnTeamKick",
+            "HookName": "OnTeamKick",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "RelationshipManager",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "kickmember",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "ConsoleSystem/Arg"
+              ]
+            },
+            "MSILHash": "wHDqeNNNzhem0KkCJMHGycJKBH2oTtAKNNvxIa8iLio=",
+            "BaseHookName": null,
+            "HookCategory": "Team"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 27,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "l2, l0",
+            "HookTypeName": "Simple",
+            "Name": "OnTeamAcceptInvite",
+            "HookName": "OnTeamAcceptInvite",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "RelationshipManager",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "acceptinvite",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "ConsoleSystem/Arg"
+              ]
+            },
+            "MSILHash": "1NEji1Ol00WtkEN+F/QToC8s5sjn4IckQAMHEGTA714=",
+            "BaseHookName": null,
+            "HookCategory": "Team"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 0,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 2,
+            "ArgumentString": null,
+            "HookTypeName": "Simple",
+            "Name": "OnTeamDisband",
+            "HookName": "OnTeamDisband",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "RelationshipManager",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "DisbandTeam",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "RelationshipManager/PlayerTeam"
+              ]
+            },
+            "MSILHash": "WZHEB/VqQkOQYyVXGSDX4woN796b/5HTs4xAQqmmUXc=",
+            "BaseHookName": null,
+            "HookCategory": "Team"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 28,
+            "ReturnBehavior": 0,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "l0, l1",
+            "HookTypeName": "Simple",
+            "Name": "OnTeamCreated",
+            "HookName": "OnTeamCreated",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "RelationshipManager",
+            "Flagged": true,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "trycreateteam",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "ConsoleSystem/Arg"
+              ]
+            },
+            "MSILHash": "NB7aDVxtM6Pcx0xoSjNUxhgjfYs84oTSJYQcqFpoyf0=",
+            "BaseHookName": "OnTeamCreate",
+            "HookCategory": "Team"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 12,
+            "ReturnBehavior": 0,
+            "ArgumentBehavior": 2,
+            "ArgumentString": null,
+            "HookTypeName": "Simple",
+            "Name": "OnTeamDisbanded",
+            "HookName": "OnTeamDisbanded",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "RelationshipManager",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "DisbandTeam",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "RelationshipManager/PlayerTeam"
+              ]
+            },
+            "MSILHash": "WZHEB/VqQkOQYyVXGSDX4woN796b/5HTs4xAQqmmUXc=",
+            "BaseHookName": "OnTeamDisband",
+            "HookCategory": "Team"
+          }
+        },
+        {
           "Type": "Modify",
           "Hook": {
             "InjectionIndex": 0,

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -11179,6 +11179,25 @@
             "Parameters": []
           },
           "MSILHash": ""
+        },
+        {
+          "Name": "BasePlayer/FiredProjectile",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "BasePlayer/FiredProjectile",
+          "Type": 3,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "FiredProjectile",
+            "FullTypeName": "BasePlayer/FiredProjectile",
+            "Parameters": []
+          },
+          "MSILHash": ""
         }
       ],
       "Fields": [

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -69,7 +69,7 @@
               "ReturnType": "System.Void",
               "Parameters": []
             },
-            "MSILHash": "EhKfGVjkYWgzzcHQ4KZtuwqSw0nkwYzZ1epx8IHOI1U=",
+            "MSILHash": "A8aiO7T9kMKyyx4PkXZOOEPkQPD9QtVQ+jO6liIa5QY=",
             "BaseHookName": null,
             "HookCategory": "Server"
           }
@@ -95,7 +95,7 @@
                 "Network.Message"
               ]
             },
-            "MSILHash": "kzMso+s/kLoJ1/fTktutd9KoPXm+orzUu36rR9bWr8c=",
+            "MSILHash": "lRJMLngCEGqeiGfdZxzL/vAodT1ZCRuiEvwp39Q7xXE=",
             "BaseHookName": null,
             "HookCategory": "Player"
           }
@@ -103,7 +103,7 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 20,
+            "InjectionIndex": 19,
             "ReturnBehavior": 0,
             "ArgumentBehavior": 4,
             "ArgumentString": "l0, a0",
@@ -122,7 +122,7 @@
                 "Network.Connection"
               ]
             },
-            "MSILHash": "v0r358Z7z9XFJq39fDz74uyQOQWteky4ygSsn8Z/nv8=",
+            "MSILHash": "Oy4OS0FRIf+HoYVgJkt7UkdLxJ4zTtdEwUTFc2dOtOQ=",
             "BaseHookName": null,
             "HookCategory": "Player"
           }
@@ -677,7 +677,7 @@
                 "BaseEntity/RPCMessage"
               ]
             },
-            "MSILHash": "rbxzM+UXoeDGJKxHcUzQyvAe9Hetj7ASsC7TeBIvNEE=",
+            "MSILHash": "/DzD12XHs2/TCd0liDR/qsuGgEC2sZ95nJ/hwk94Iyc=",
             "BaseHookName": null,
             "HookCategory": "Player"
           }
@@ -730,7 +730,7 @@
                 "Network.Connection"
               ]
             },
-            "MSILHash": "2t/J26dIeMSaQxZFzhVh2PCar5XjBL+zw7Qt68LH7Qc=",
+            "MSILHash": "cnZ7XEWiQHhPqDQEGcu18wQGz1fu9/mbQHjphlv9jOo=",
             "BaseHookName": null,
             "HookCategory": "Player"
           }
@@ -756,7 +756,7 @@
                 "BaseEntity/RPCMessage"
               ]
             },
-            "MSILHash": "BeNww6v1bLw3EnkHHrwEF+PIm56Z8Ywf121NqBamS7Y=",
+            "MSILHash": "Rn0y7V3yynLtv1wH77RUYyinemtpKA8OMfk+d1I8gWo=",
             "BaseHookName": null,
             "HookCategory": "Structure"
           }
@@ -913,7 +913,7 @@
                 "BaseEntity/RPCMessage"
               ]
             },
-            "MSILHash": "voX4rr624CziGyNxW4Lj99ZZWymdm4/koY/dLiNK0dQ=",
+            "MSILHash": "whyU+eytVFhy+Z/yy+8/u+YWtEEW7o8axKYI9NnSyFA=",
             "BaseHookName": null,
             "HookCategory": "Structure"
           }
@@ -1129,7 +1129,7 @@
             "InjectionIndex": 115,
             "ReturnBehavior": 0,
             "ArgumentBehavior": 4,
-            "ArgumentString": "a0.player, l3",
+            "ArgumentString": "a0.player, l3, this",
             "HookTypeName": "Simple",
             "Name": "OnExplosiveThrown",
             "HookName": "OnExplosiveThrown",
@@ -1144,7 +1144,7 @@
                 "BaseEntity/RPCMessage"
               ]
             },
-            "MSILHash": "rRXp6LlpKcDJQ5AW0ryavGdz6XGI9mViKVhqT17pbk4=",
+            "MSILHash": "gE6DXo4PsGE+MrbArPLEVQD1LSimU+i0Wa1FK0PS0BM=",
             "BaseHookName": null,
             "HookCategory": "Weapon"
           }
@@ -1170,7 +1170,7 @@
                 "BaseEntity/RPCMessage"
               ]
             },
-            "MSILHash": "UKnIzo2f1Jl3TO2xEI2UU/lCIDiFVHRgZzgsxvyB4LI=",
+            "MSILHash": "O8iryYASdbFR8uXJGaMNnLRWnWgvYIZ7mugm9hlFb3o=",
             "BaseHookName": null,
             "HookCategory": "Weapon"
           }
@@ -1376,7 +1376,7 @@
                 "BaseEntity/RPCMessage"
               ]
             },
-            "MSILHash": "PeDugO4Bi8+n8jSHOZSgZaegDPtNPcScGdPovPBI2Uk=",
+            "MSILHash": "EnJ82+G64g8wioj0BN6lGIK9A7pbamA/29vxMvBaUtU=",
             "BaseHookName": null,
             "HookCategory": "Weapon"
           }
@@ -1402,7 +1402,7 @@
                 "BaseEntity/RPCMessage"
               ]
             },
-            "MSILHash": "dgd8sk6vRuXiAJxEDxeodx6IX5STFA7zGMjTHccR/As=",
+            "MSILHash": "PF+ZpaVPNVR/TM3AkwWp2QwexpTz0s1gDW1cnu+5WDM=",
             "BaseHookName": null,
             "HookCategory": "Weapon"
           }
@@ -1502,35 +1502,9 @@
               "ReturnType": "System.Void",
               "Parameters": []
             },
-            "MSILHash": "U8X0WIP/tTq33l+6Ke/on8yYnKW31iymfql4eT+OQaw=",
+            "MSILHash": "3XDakQ+XhDNBXjgqvxEb+I52SObPSPa+1dixfpQ3y0k=",
             "BaseHookName": null,
             "HookCategory": "__Broken__"
-          }
-        },
-        {
-          "Type": "Simple",
-          "Hook": {
-            "InjectionIndex": 28,
-            "ReturnBehavior": 1,
-            "ArgumentBehavior": 4,
-            "ArgumentString": "l3, a0.player, this",
-            "HookTypeName": "Simple",
-            "Name": "OnCollectiblePickup",
-            "HookName": "OnCollectiblePickup",
-            "AssemblyName": "Assembly-CSharp.dll",
-            "TypeName": "CollectibleEntity",
-            "Flagged": false,
-            "Signature": {
-              "Exposure": 2,
-              "Name": "Pickup",
-              "ReturnType": "System.Void",
-              "Parameters": [
-                "BaseEntity/RPCMessage"
-              ]
-            },
-            "MSILHash": "UOlzEsIaRuSHQB/+8c6LBNoPJjU/HXA2khXMR67eqsM=",
-            "BaseHookName": null,
-            "HookCategory": "Resource"
           }
         },
         {
@@ -1607,32 +1581,6 @@
               ]
             },
             "MSILHash": "iwh6KDAFZq2FxBSPwbsYLe5mAKJew5zKMuGhEZsb08g=",
-            "BaseHookName": null,
-            "HookCategory": "Resource"
-          }
-        },
-        {
-          "Type": "Simple",
-          "Hook": {
-            "InjectionIndex": 57,
-            "ReturnBehavior": 1,
-            "ArgumentBehavior": 4,
-            "ArgumentString": "this, l3, a0.player",
-            "HookTypeName": "Simple",
-            "Name": "OnCropGather",
-            "HookName": "OnCropGather",
-            "AssemblyName": "Assembly-CSharp.dll",
-            "TypeName": "PlantEntity",
-            "Flagged": false,
-            "Signature": {
-              "Exposure": 2,
-              "Name": "RPC_PickFruit",
-              "ReturnType": "System.Void",
-              "Parameters": [
-                "BaseEntity/RPCMessage"
-              ]
-            },
-            "MSILHash": "8e1TOtLgNP8VohcA+fJrlGd6Du9+tMbRPwVLUmfDBQg=",
             "BaseHookName": null,
             "HookCategory": "Resource"
           }
@@ -1762,7 +1710,7 @@
                 "BaseEntity/RPCMessage"
               ]
             },
-            "MSILHash": "mY57WW2INsbznsZFNgkr0glhE2+/vV0HINj4dFunnSs=",
+            "MSILHash": "+oxtfpdiuXHOtw/GwI9EJ65dPQ27WXkVeiG/rk4TFFo=",
             "BaseHookName": null,
             "HookCategory": "Item"
           }
@@ -2164,13 +2112,13 @@
         {
           "Type": "Modify",
           "Hook": {
-            "InjectionIndex": 81,
+            "InjectionIndex": 85,
             "RemoveCount": 0,
             "Instructions": [
               {
-                "OpCode": "ldloc_3",
-                "OpType": "None",
-                "Operand": null
+                "OpCode": "call",
+                "OpType": "Method",
+                "Operand": "Facepunch.Steamworks|Steamworks.SteamServer|get_GameTags"
               },
               {
                 "OpCode": "ldstr",
@@ -2183,9 +2131,9 @@
                 "Operand": "mscorlib|System.String|Concat(System.String, System.String)"
               },
               {
-                "OpCode": "stloc_3",
-                "OpType": "None",
-                "Operand": null
+                "OpCode": "call",
+                "OpType": "Method",
+                "Operand": "Facepunch.Steamworks|Steamworks.SteamServer|set_GameTags"
               },
               {
                 "OpCode": "call",
@@ -2210,12 +2158,12 @@
               {
                 "OpCode": "brfalse",
                 "OpType": "Instruction",
-                "Operand": 81
+                "Operand": 85
               },
               {
-                "OpCode": "ldloc_3",
-                "OpType": "None",
-                "Operand": null
+                "OpCode": "call",
+                "OpType": "Method",
+                "Operand": "Facepunch.Steamworks|Steamworks.SteamServer|get_GameTags"
               },
               {
                 "OpCode": "ldstr",
@@ -2228,9 +2176,9 @@
                 "Operand": "mscorlib|System.String|Concat(System.String, System.String)"
               },
               {
-                "OpCode": "stloc_3",
-                "OpType": "None",
-                "Operand": null
+                "OpCode": "call",
+                "OpType": "Method",
+                "Operand": "Facepunch.Steamworks|Steamworks.SteamServer|set_GameTags"
               }
             ],
             "HookTypeName": "Modify",
@@ -2245,7 +2193,7 @@
               "ReturnType": "System.Void",
               "Parameters": []
             },
-            "MSILHash": "U4e8rfIXzHnWxRnW8mTp3IXv4UL+jc8SJIx0kNDaVmU=",
+            "MSILHash": "CmrFxTqdHZQt2AyRHVfM0u/IZzyLPkLSE4IvjCDJLDc=",
             "BaseHookName": null,
             "HookCategory": "_Patches"
           }
@@ -2649,7 +2597,7 @@
                 "Network.Message"
               ]
             },
-            "MSILHash": "HWYanqpQTLCBnF2ejygrxciuRAvHX/qBEtXb20brd04=",
+            "MSILHash": "ZQX1IN+6BkKW+zaoxyQHkyHyHmXmEGAU5w9znbw8ElY=",
             "BaseHookName": null,
             "HookCategory": "Player"
           }
@@ -2676,7 +2624,7 @@
                 "System.Boolean"
               ]
             },
-            "MSILHash": "CfrnPiioH3iVea1CijtHAedIVb+CcNPHbmsJSyjrSLU=",
+            "MSILHash": "s/Mfp2N9ds4P7ljgPyl5kHOhwX6Vqz56lCdIr+QA3Vw=",
             "BaseHookName": null,
             "HookCategory": "Server"
           }
@@ -2727,7 +2675,7 @@
                 "System.Boolean"
               ]
             },
-            "MSILHash": "CfrnPiioH3iVea1CijtHAedIVb+CcNPHbmsJSyjrSLU=",
+            "MSILHash": "s/Mfp2N9ds4P7ljgPyl5kHOhwX6Vqz56lCdIr+QA3Vw=",
             "BaseHookName": "OnNewSave",
             "HookCategory": "Server"
           }
@@ -2974,7 +2922,7 @@
                 "HitInfo"
               ]
             },
-            "MSILHash": "r27NxXcmgLvGbQpzjiYhQYCXAV585uQJwr7loqbdBAY=",
+            "MSILHash": "KNbrrlOP9ygkLWaBnRO1rpIAGJ7QaAkmXHUNfJOpto8=",
             "BaseHookName": null,
             "HookCategory": "Player"
           }
@@ -3052,7 +3000,7 @@
                 "BaseEntity/RPCMessage"
               ]
             },
-            "MSILHash": "tUcZF7rLgUqmdTNSL3yWfC6nPW7wU/EIFSpCR0AeBa0=",
+            "MSILHash": "z90ORG6IkdbeWEe+qHOwIpsxnRPBlKRnVJha6OMG6y0=",
             "BaseHookName": null,
             "HookCategory": "Entity"
           }
@@ -3107,32 +3055,6 @@
             "MSILHash": "9kXTW34S23lEXuRLSG2QdZqGu2nZfiNInplSjx6Dcf8=",
             "BaseHookName": null,
             "HookCategory": "Trap"
-          }
-        },
-        {
-          "Type": "Simple",
-          "Hook": {
-            "InjectionIndex": 87,
-            "ReturnBehavior": 1,
-            "ArgumentBehavior": 4,
-            "ArgumentString": "this, l4, a0.player",
-            "HookTypeName": "Simple",
-            "Name": "OnCropGather [!condition]",
-            "HookName": "OnCropGather",
-            "AssemblyName": "Assembly-CSharp.dll",
-            "TypeName": "PlantEntity",
-            "Flagged": false,
-            "Signature": {
-              "Exposure": 2,
-              "Name": "RPC_PickFruit",
-              "ReturnType": "System.Void",
-              "Parameters": [
-                "BaseEntity/RPCMessage"
-              ]
-            },
-            "MSILHash": "8e1TOtLgNP8VohcA+fJrlGd6Du9+tMbRPwVLUmfDBQg=",
-            "BaseHookName": "OnCropGather",
-            "HookCategory": "Resource"
           }
         },
         {
@@ -3239,7 +3161,7 @@
             "InjectionIndex": 111,
             "ReturnBehavior": 0,
             "ArgumentBehavior": 4,
-            "ArgumentString": "a0.player, l2",
+            "ArgumentString": "a0.player, l2, this",
             "HookTypeName": "Simple",
             "Name": "OnExplosiveDropped",
             "HookName": "OnExplosiveDropped",
@@ -3254,7 +3176,7 @@
                 "BaseEntity/RPCMessage"
               ]
             },
-            "MSILHash": "JBRqT0JGArLxOJEagK7rQGO1aQSpMv2WhmHHeigHCls=",
+            "MSILHash": "GJjuCx5UYPYPZPAfZEju3qhBm/FGTPrrtjyT2wi9LHc=",
             "BaseHookName": null,
             "HookCategory": "Weapon"
           }
@@ -3280,7 +3202,7 @@
                 "BaseEntity/RPCMessage"
               ]
             },
-            "MSILHash": "mwj9d2igRqWDLIfhX98aNFq0n9y4BNhuPnj6Bzm0SCw=",
+            "MSILHash": "DlhvcWoQ6RpmInz0M3rSyri3y3V3CwsGxmchu6yNYQ4=",
             "BaseHookName": null,
             "HookCategory": "Vending"
           }
@@ -3413,7 +3335,7 @@
                 "BaseEntity/RPCMessage"
               ]
             },
-            "MSILHash": "MQnyG73Vj8Ubu4eyc4lyrgETjCuFUA0Gr1EPbL0ia+g=",
+            "MSILHash": "ZcFnAX/39EB3ubTBzeBYIJibQtHSCP3cMAFnVazltkE=",
             "BaseHookName": null,
             "HookCategory": "Vending"
           }
@@ -3439,7 +3361,7 @@
                 "BaseEntity/RPCMessage"
               ]
             },
-            "MSILHash": "elnqoZ4KbCo5iDSI7RXiF7KdCtSRsXnkf/uBlsZU2Ko=",
+            "MSILHash": "M2CVdZGluaaaNaEJDZg4YfPoRhg3eIycFIVzgqzQPbg=",
             "BaseHookName": null,
             "HookCategory": "Vending"
           }
@@ -3624,7 +3546,7 @@
                 "BaseEntity/RPCMessage"
               ]
             },
-            "MSILHash": "FDmwcdQoX6qx4vIuJjwIpUMKVQ9myNDhasT+NVTV4xQ=",
+            "MSILHash": "Fyn+NCIzSUbW/FuhhQmCBcQjoT7dePhxWJcDAPalyzU=",
             "BaseHookName": null,
             "HookCategory": "Item"
           }
@@ -3650,7 +3572,7 @@
                 "BaseEntity/RPCMessage"
               ]
             },
-            "MSILHash": "n70Pv74m9cagkFc2ZY89cqu2FmYP/mLeiCMkJhGDe7o=",
+            "MSILHash": "Y6Tms1mQtCHMGSaIm3BbAK/VK7DIHveXrUZ8cMIhn+E=",
             "BaseHookName": null,
             "HookCategory": "Player"
           }
@@ -3676,7 +3598,7 @@
                 "BaseEntity/RPCMessage"
               ]
             },
-            "MSILHash": "8YIdMu6UfwbSwuRrKdoR1VOL2d8PSWKkw7DqdSUGMrs=",
+            "MSILHash": "Dvhj3Mvhir8g7Z6xhXhUJv7W/jHQCGNFl4ekkNrmioY=",
             "BaseHookName": null,
             "HookCategory": "Structure"
           }
@@ -3754,7 +3676,7 @@
                 "BaseEntity/RPCMessage"
               ]
             },
-            "MSILHash": "0eRsTA8mtcaqf/jjklQJ5T/iAqjGcPw8l8RNMBAD4j8=",
+            "MSILHash": "cFA5ZfTDPI/QbreW7HPy/xud+XRxaYOGpJKTCv8x/9c=",
             "BaseHookName": null,
             "HookCategory": "Player"
           }
@@ -3832,7 +3754,7 @@
                 "BaseEntity/RPCMessage"
               ]
             },
-            "MSILHash": "Gn3jMlKrqOc7SqBocXWewclMbV/fPyiSB9x6n7KBYlc=",
+            "MSILHash": "4rIIey33aafLwMS07y5ErHcWR3Xm3AMAdCX/6GagW54=",
             "BaseHookName": null,
             "HookCategory": "Entity"
           }
@@ -3958,7 +3880,7 @@
                 "BaseEntity/RPCMessage"
               ]
             },
-            "MSILHash": "0qpLk+bphw4y9/iwfx6Ogfqt1J1S1Z2rzn3jIukqGM0=",
+            "MSILHash": "uKWmi6rxhRO+fLG0xUtRH+3SsAwTHn0ZOKgve3xi+cw=",
             "BaseHookName": null,
             "HookCategory": "Player"
           }
@@ -4065,7 +3987,7 @@
                 "BaseEntity/RPCMessage"
               ]
             },
-            "MSILHash": "LOdV1uubuyp9ITh5NxfpXHItYTGXD/KNYdp4CLzES+k=",
+            "MSILHash": "ZzQ6zqlC5I49TjIOCliTf/Sc311ynqmNGqsbxKpdsYg=",
             "BaseHookName": null,
             "HookCategory": "Item"
           }
@@ -4394,7 +4316,7 @@
                 "BaseEntity/RPCMessage"
               ]
             },
-            "MSILHash": "HdEjgctLIB2eUnM6PanQX+9cBkYRjlrxQ4At0vX+HeE=",
+            "MSILHash": "4PNaxJ1dps7X5kJXRrIJRP5y2NGEe6XfXrZrX+BPGNg=",
             "BaseHookName": null,
             "HookCategory": "Player"
           }
@@ -5159,7 +5081,7 @@
                 "System.Boolean"
               ]
             },
-            "MSILHash": "LHSGzJlpfmUEISyBrePph4S2qln5+G6nyX/k9Jfafjw=",
+            "MSILHash": "3LbrFPbQpDWijtp15j2tPe8cfDxDWgVp25anwAzKZSY=",
             "BaseHookName": null,
             "HookCategory": "Player"
           }
@@ -5167,7 +5089,7 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 171,
+            "InjectionIndex": 173,
             "ReturnBehavior": 0,
             "ArgumentBehavior": 4,
             "ArgumentString": "this, a0",
@@ -5186,7 +5108,7 @@
                 "System.Boolean"
               ]
             },
-            "MSILHash": "LHSGzJlpfmUEISyBrePph4S2qln5+G6nyX/k9Jfafjw=",
+            "MSILHash": "3LbrFPbQpDWijtp15j2tPe8cfDxDWgVp25anwAzKZSY=",
             "BaseHookName": "CanDismountEntity",
             "HookCategory": "Player"
           }
@@ -5317,7 +5239,7 @@
                 "Item"
               ]
             },
-            "MSILHash": "yHsK6XOcmreHpj/8S4A38JKuPgcD3Z0tQX4W/BIwFqQ=",
+            "MSILHash": "Hh12jVwIGdysyVr7wGxfQIpdwcjPwKtL/GyurAKfEcM=",
             "BaseHookName": null,
             "HookCategory": "Item"
           }
@@ -5526,7 +5448,7 @@
                 "BaseEntity/RPCMessage"
               ]
             },
-            "MSILHash": "XgtXeplqV8mfuJCWhvW8LK8pmNemOJm5CJJGSjzcbXA=",
+            "MSILHash": "aWhRqQWJlnDjXvRNnfmuhM/TDgNn0v6i/uHNQLWzMeg=",
             "BaseHookName": null,
             "HookCategory": "Weapon"
           }
@@ -6512,7 +6434,7 @@
                 "BaseEntity/RPCMessage"
               ]
             },
-            "MSILHash": "AtOVA8XGCykUZWnklZFU7pKIQ/UrAy58xy3GSDnD+GE=",
+            "MSILHash": "RMy/YNRYBvaGEe4bzpY39afCnyytLfHeACgDFEYQlkY=",
             "BaseHookName": null,
             "HookCategory": "Player"
           }
@@ -6543,7 +6465,7 @@
                 "BaseEntity/RPCMessage"
               ]
             },
-            "MSILHash": "LOdV1uubuyp9ITh5NxfpXHItYTGXD/KNYdp4CLzES+k=",
+            "MSILHash": "ZzQ6zqlC5I49TjIOCliTf/Sc311ynqmNGqsbxKpdsYg=",
             "BaseHookName": "CanMoveItem",
             "HookCategory": "_Patches"
           }
@@ -6903,6 +6825,45 @@
             "MSILHash": "EImSHh5yFKp/mT2Z/21nTlt6oXfAs11iFxiDdD2h5WA=",
             "BaseHookName": null,
             "HookCategory": "Entity"
+          }
+        },
+        {
+          "Type": "Modify",
+          "Hook": {
+            "InjectionIndex": 109,
+            "RemoveCount": 0,
+            "Instructions": [
+              {
+                "OpCode": "ldstr",
+                "OpType": "String",
+                "Operand": "description_0"
+              },
+              {
+                "OpCode": "ldsfld",
+                "OpType": "Field",
+                "Operand": "mscorlib|System.String|Empty"
+              },
+              {
+                "OpCode": "callvirt",
+                "OpType": "Method",
+                "Operand": "Facepunch.Steamworks|Steamworks.SteamServer|SetKey"
+              }
+            ],
+            "HookTypeName": "Modify",
+            "Name": "FixDescriptionUpdating [patch]",
+            "HookName": "FixDescriptionUpdating [patch]",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "ServerMgr",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 0,
+              "Name": "UpdateServerInformation",
+              "ReturnType": "System.Void",
+              "Parameters": []
+            },
+            "MSILHash": "CmrFxTqdHZQt2AyRHVfM0u/IZzyLPkLSE4IvjCDJLDc=",
+            "BaseHookName": "AddGameTags [patch]",
+            "HookCategory": "_Patches"
           }
         },
         {
@@ -7630,7 +7591,7 @@
               {
                 "OpCode": "brtrue",
                 "OpType": "Instruction",
-                "Operand": 69
+                "Operand": 68
               }
             ],
             "HookTypeName": "Modify",
@@ -7649,7 +7610,7 @@
                 "UnityEngine.LogType"
               ]
             },
-            "MSILHash": "zxbUUEBy8Lr/Y2tcsZ9h1DxlmthdQNmp+nvzO/j0VyA=",
+            "MSILHash": "kgtD5ffonym/f+Zj8bJzE5DdXLcFDUVuEFzVLJFOY1g=",
             "BaseHookName": null,
             "HookCategory": "_Patches"
           }
@@ -7976,7 +7937,7 @@
                 "BaseEntity/RPCMessage"
               ]
             },
-            "MSILHash": "SkVCRyntL+yn+a3fXLiH4lCfsU68Yu4SHZeAdMbDimk=",
+            "MSILHash": "5Qq7EgPBmmyiZyQusAFtai4wnj+bFxFtTuoF3zcmEHA=",
             "BaseHookName": null,
             "HookCategory": "Player"
           }
@@ -8084,6 +8045,110 @@
             "MSILHash": "6w4stUt6n3+3vU3xhEStULnO+GY923iX1oa0EpdPssA=",
             "BaseHookName": null,
             "HookCategory": "Vehicle"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 28,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "l3, a0, this",
+            "HookTypeName": "Simple",
+            "Name": "OnCollectiblePickup",
+            "HookName": "OnCollectiblePickup",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "CollectibleEntity",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "DoPickup",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "BasePlayer"
+              ]
+            },
+            "MSILHash": "hPuZGjNHmNHRVf7jQlBYtzDYim8avvl014EbvwpzTj4=",
+            "BaseHookName": null,
+            "HookCategory": "Resource"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 60,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, l3, a0",
+            "HookTypeName": "Simple",
+            "Name": "OnCropGather",
+            "HookName": "OnCropGather",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "PlantEntity",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "PickFruit",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "BasePlayer"
+              ]
+            },
+            "MSILHash": "xeobsyL4/jkbvExAXlhCrRuv2oygntsNs/Z9ji7E8Yk=",
+            "BaseHookName": null,
+            "HookCategory": "Resource"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 108,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, l5, a0",
+            "HookTypeName": "Simple",
+            "Name": "OnCropGather [!condition]",
+            "HookName": "OnCropGather",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "PlantEntity",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "PickFruit",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "BasePlayer"
+              ]
+            },
+            "MSILHash": "xeobsyL4/jkbvExAXlhCrRuv2oygntsNs/Z9ji7E8Yk=",
+            "BaseHookName": "OnCropGather",
+            "HookCategory": "Resource"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 371,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, l0",
+            "HookTypeName": "Simple",
+            "Name": "OnProjectileRicochet",
+            "HookName": "OnProjectileRicochet",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "BasePlayer",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "OnProjectileRicochet",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "BaseEntity/RPCMessage"
+              ]
+            },
+            "MSILHash": "q7KzcFwBeP/Fr6OUbmC/BeRNkRxYamGZf0xb3YnhbL8=",
+            "BaseHookName": null,
+            "HookCategory": "Weapon"
           }
         }
       ],

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -6682,8 +6682,8 @@
           "Hook": {
             "InjectionIndex": 118,
             "ReturnBehavior": 1,
-            "ArgumentBehavior": 2,
-            "ArgumentString": null,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "a0, l1",
             "HookTypeName": "Simple",
             "Name": "IOnPlayerChat [internal]",
             "HookName": "IOnPlayerChat",

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -499,7 +499,7 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 100,
+            "InjectionIndex": 107,
             "ReturnBehavior": 0,
             "ArgumentBehavior": 4,
             "ArgumentString": "this, l1",
@@ -519,7 +519,7 @@
                 "System.UInt32"
               ]
             },
-            "MSILHash": "KeqqPZW4dzkLctq+AFFZCVqS/hsFEauwW+ejYVqGcto=",
+            "MSILHash": "krG4H8P7CU1G/WvGybUrMNuHhQImrV/27n542OE5BlI=",
             "BaseHookName": null,
             "HookCategory": "Item"
           }
@@ -659,7 +659,7 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 882,
+            "InjectionIndex": 999,
             "ReturnBehavior": 1,
             "ArgumentBehavior": 4,
             "ArgumentString": "this, l2",
@@ -677,7 +677,7 @@
                 "BaseEntity/RPCMessage"
               ]
             },
-            "MSILHash": "qGXKLwLB/gUWsggFttswywXh/WrzbdRZhFyxL+nIJHk=",
+            "MSILHash": "rbxzM+UXoeDGJKxHcUzQyvAe9Hetj7ASsC7TeBIvNEE=",
             "BaseHookName": null,
             "HookCategory": "Player"
           }

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -3156,7 +3156,7 @@
             },
             "MSILHash": "bcyJmGroXTIUU3OPYSNHGVkJ5PbaEAS/WksDoe8zpxU=",
             "BaseHookName": null,
-            "HookCategory": "Server"
+            "HookCategory": "World"
           }
         },
         {
@@ -7927,6 +7927,139 @@
             "MSILHash": "XAbBUjv9aYi01AmWlvIJ98FqWYe3fbF070HqXQjRTuM=",
             "BaseHookName": "OnPlayerLand",
             "HookCategory": "Player"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 37,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "l0, this",
+            "HookTypeName": "Simple",
+            "Name": "CanPushBoat",
+            "HookName": "CanPushBoat",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "MotorRowboat",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "RPC_WantsPush",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "BaseEntity/RPCMessage"
+              ]
+            },
+            "MSILHash": "T2E58SMg0QDjlD12ilDCFL9p1zT8qmN+HJmwol5fj34=",
+            "BaseHookName": null,
+            "HookCategory": "Player"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 21,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "a0.player, l0",
+            "HookTypeName": "Simple",
+            "Name": "CanDeployItem",
+            "HookName": "CanDeployItem",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "Deployer",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 0,
+              "Name": "DoDeploy",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "BaseEntity/RPCMessage"
+              ]
+            },
+            "MSILHash": "SkVCRyntL+yn+a3fXLiH4lCfsU68Yu4SHZeAdMbDimk=",
+            "BaseHookName": null,
+            "HookCategory": "Player"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 61,
+            "ReturnBehavior": 0,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, l8",
+            "HookTypeName": "Simple",
+            "Name": "OnBigWheelLoss",
+            "HookName": "OnBigWheelLoss",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "BigWheelGame",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "Payout",
+              "ReturnType": "System.Void",
+              "Parameters": []
+            },
+            "MSILHash": "AN3Y9M83Owfjbcds1Yv6YHo6X4fl37GMjApk3gQdImE=",
+            "BaseHookName": null,
+            "HookCategory": "Entity"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 12,
+            "ReturnBehavior": 0,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "l0, a0",
+            "HookTypeName": "Simple",
+            "Name": "OnWorldPrefabSpawned",
+            "HookName": "OnWorldPrefabSpawned",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "World",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 0,
+              "Name": "Spawn",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "System.String",
+                "System.UInt32",
+                "UnityEngine.Vector3",
+                "UnityEngine.Quaternion",
+                "UnityEngine.Vector3"
+              ]
+            },
+            "MSILHash": "3WG5GI59jmn7KSSui18gYW4m84aEKPye1EwvATFDcXI=",
+            "BaseHookName": null,
+            "HookCategory": "World"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 0,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 1,
+            "ArgumentString": null,
+            "HookTypeName": "Simple",
+            "Name": "OnBoatPathGenerate",
+            "HookName": "OnBoatPathGenerate",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "BaseBoat",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "GenerateOceanPatrolPath",
+              "ReturnType": "System.Collections.Generic.List`1<UnityEngine.Vector3>",
+              "Parameters": [
+                "System.Single",
+                "System.Single"
+              ]
+            },
+            "MSILHash": "6w4stUt6n3+3vU3xhEStULnO+GY923iX1oa0EpdPssA=",
+            "BaseHookName": null,
+            "HookCategory": "Vehicle"
           }
         }
       ],

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -8008,6 +8008,30 @@
         {
           "Type": "Simple",
           "Hook": {
+            "InjectionIndex": 40,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 1,
+            "ArgumentString": null,
+            "HookTypeName": "Simple",
+            "Name": "CanSamSiteShoot",
+            "HookName": "CanSamSiteShoot",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "SamSite",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "WeaponTick",
+              "ReturnType": "System.Void",
+              "Parameters": []
+            },
+            "MSILHash": "UEuh5wug5rmyYj5RnAx3FOuIZ7Q+blYz2n3hEugtAIA=",
+            "BaseHookName": null,
+            "HookCategory": "Entity"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
             "InjectionIndex": 12,
             "ReturnBehavior": 0,
             "ArgumentBehavior": 4,

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -7130,7 +7130,7 @@
             "HookName": "OnNpcPlayerTarget",
             "AssemblyName": "Assembly-CSharp.dll",
             "TypeName": "NPCPlayerApex",
-            "Flagged": false,
+            "Flagged": true,
             "Signature": {
               "Exposure": 2,
               "Name": "UpdateTargetMemory",

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -4736,6 +4736,112 @@
         {
           "Type": "Simple",
           "Hook": {
+            "InjectionIndex": 0,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "a0, this",
+            "HookTypeName": "Simple",
+            "Name": "CanAdministerVending [npc]",
+            "HookName": "CanAdministerVending",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "NPCVendingMachine",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "CanPlayerAdmin",
+              "ReturnType": "System.Boolean",
+              "Parameters": [
+                "BasePlayer"
+              ]
+            },
+            "MSILHash": "RQzLETIQY8oCXnENh9Yiq2D0HFlL85DvhJ8pbAWKDf4=",
+            "BaseHookName": null,
+            "HookCategory": "Vending"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 0,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, a0, a1",
+            "HookTypeName": "Simple",
+            "Name": "CanGiveSoldItem",
+            "HookName": "CanGiveSoldItem",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "VendingMachine",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "GiveSoldItem",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "Item",
+                "BasePlayer"
+              ]
+            },
+            "MSILHash": "TtlTKoGKq571dPkJLzgXBDwdF9JM2Xu1tvgypvvTLhE=",
+            "BaseHookName": null,
+            "HookCategory": "Vending"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 0,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, a0, a1",
+            "HookTypeName": "Simple",
+            "Name": "CanGiveSoldItem [npc]",
+            "HookName": "CanGiveSoldItem",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "NPCVendingMachine",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "GiveSoldItem",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "Item",
+                "BasePlayer"
+              ]
+            },
+            "MSILHash": "XEi8FPWQsf5CtKWrdJQteuLMu77nyCURbLGfTY4RQYo=",
+            "BaseHookName": null,
+            "HookCategory": "Vending"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 13,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "l0, this, l1",
+            "HookTypeName": "Simple",
+            "Name": "CanRenameShop",
+            "HookName": "CanRenameShop",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "VendingMachine",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "RPC_UpdateShopName",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "BaseEntity/RPCMessage"
+              ]
+            },
+            "MSILHash": "VBHE3/FMHu4TK5gqzrDcNyZBMCMRQV9Lkyc9Rh9KVlg=",
+            "BaseHookName": null,
+            "HookCategory": "Vending"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
             "InjectionIndex": 5,
             "ReturnBehavior": 1,
             "ArgumentBehavior": 4,

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -1486,7 +1486,7 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 111,
+            "InjectionIndex": 112,
             "ReturnBehavior": 0,
             "ArgumentBehavior": 4,
             "ArgumentString": "this, l11",
@@ -6690,7 +6690,7 @@
             "HookName": "OnFlameExplosion",
             "AssemblyName": "Assembly-CSharp.dll",
             "TypeName": "FlameExplosive",
-            "Flagged": false,
+            "Flagged": true,
             "Signature": {
               "Exposure": 2,
               "Name": "Explode",

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -7366,6 +7366,306 @@
             "BaseHookName": "IOnPlayerChat [internal]",
             "HookCategory": "_Patches"
           }
+        },
+        {
+          "Type": "Modify",
+          "Hook": {
+            "InjectionIndex": 0,
+            "RemoveCount": 0,
+            "Instructions": [
+              {
+                "OpCode": "call",
+                "OpType": "Method",
+                "Operand": "mscorlib|System.Environment|get_OSVersion"
+              },
+              {
+                "OpCode": "callvirt",
+                "OpType": "Method",
+                "Operand": "mscorlib|System.OperatingSystem|get_Platform"
+              },
+              {
+                "OpCode": "ldc_i4_2",
+                "OpType": "None",
+                "Operand": null
+              },
+              {
+                "OpCode": "ceq",
+                "OpType": "None",
+                "Operand": null
+              },
+              {
+                "OpCode": "brfalse",
+                "OpType": "Instruction",
+                "Operand": 29
+              }
+            ],
+            "HookTypeName": "Modify",
+            "Name": "ConsoleEnableWinOnly [patch]",
+            "HookName": "ConsoleEnableWinOnly [patch]",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "ServerConsole",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "OnEnable",
+              "ReturnType": "System.Void",
+              "Parameters": []
+            },
+            "MSILHash": "FiSe0dzBG4Gojuwy6thYkYL70dXLZcns6fH3a7zyjb4=",
+            "BaseHookName": null,
+            "HookCategory": "_Patches"
+          }
+        },
+        {
+          "Type": "Modify",
+          "Hook": {
+            "InjectionIndex": 0,
+            "RemoveCount": 0,
+            "Instructions": [
+              {
+                "OpCode": "call",
+                "OpType": "Method",
+                "Operand": "mscorlib|System.Environment|get_OSVersion"
+              },
+              {
+                "OpCode": "callvirt",
+                "OpType": "Method",
+                "Operand": "mscorlib|System.OperatingSystem|get_Platform"
+              },
+              {
+                "OpCode": "ldc_i4_2",
+                "OpType": "None",
+                "Operand": null
+              },
+              {
+                "OpCode": "ceq",
+                "OpType": "None",
+                "Operand": null
+              },
+              {
+                "OpCode": "brfalse",
+                "OpType": "Instruction",
+                "Operand": 69
+              }
+            ],
+            "HookTypeName": "Modify",
+            "Name": "ConsoleHandleLogWinOnly [patch]",
+            "HookName": "ConsoleHandleLogWinOnly [patch]",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "ServerConsole",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 0,
+              "Name": "HandleLog",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "System.String",
+                "System.String",
+                "UnityEngine.LogType"
+              ]
+            },
+            "MSILHash": "zxbUUEBy8Lr/Y2tcsZ9h1DxlmthdQNmp+nvzO/j0VyA=",
+            "BaseHookName": null,
+            "HookCategory": "_Patches"
+          }
+        },
+        {
+          "Type": "Modify",
+          "Hook": {
+            "InjectionIndex": 4,
+            "RemoveCount": 0,
+            "Instructions": [
+              {
+                "OpCode": "call",
+                "OpType": "Method",
+                "Operand": "mscorlib|System.Environment|get_OSVersion"
+              },
+              {
+                "OpCode": "callvirt",
+                "OpType": "Method",
+                "Operand": "mscorlib|System.OperatingSystem|get_Platform"
+              },
+              {
+                "OpCode": "ldc_i4_2",
+                "OpType": "None",
+                "Operand": null
+              },
+              {
+                "OpCode": "ceq",
+                "OpType": "None",
+                "Operand": null
+              },
+              {
+                "OpCode": "brfalse",
+                "OpType": "Instruction",
+                "Operand": 13
+              }
+            ],
+            "HookTypeName": "Modify",
+            "Name": "ConsoleDisableWinOnly [patch]",
+            "HookName": "ConsoleDisableWinOnly [patch]",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "ServerConsole",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 0,
+              "Name": "OnDisable",
+              "ReturnType": "System.Void",
+              "Parameters": []
+            },
+            "MSILHash": "qH0Fx4ZpZ52rsWOYB9nD/cxYExr6N+/oLjCJei6InME=",
+            "BaseHookName": null,
+            "HookCategory": "_Patches"
+          }
+        },
+        {
+          "Type": "Modify",
+          "Hook": {
+            "InjectionIndex": 0,
+            "RemoveCount": 0,
+            "Instructions": [
+              {
+                "OpCode": "call",
+                "OpType": "Method",
+                "Operand": "mscorlib|System.Environment|get_OSVersion"
+              },
+              {
+                "OpCode": "callvirt",
+                "OpType": "Method",
+                "Operand": "mscorlib|System.OperatingSystem|get_Platform"
+              },
+              {
+                "OpCode": "ldc_i4_2",
+                "OpType": "None",
+                "Operand": null
+              },
+              {
+                "OpCode": "ceq",
+                "OpType": "None",
+                "Operand": null
+              },
+              {
+                "OpCode": "brfalse",
+                "OpType": "Instruction",
+                "Operand": 49
+              }
+            ],
+            "HookTypeName": "Modify",
+            "Name": "ConsolePrintWinOnly [patch]",
+            "HookName": "ConsolePrintWinOnly [patch]",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "ServerConsole",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "PrintColoured",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "System.Object[]"
+              ]
+            },
+            "MSILHash": "UI86dHyItG7auqsoY9Zk936ttdcLX2uvBUQ95+KCkEw=",
+            "BaseHookName": null,
+            "HookCategory": "_Patches"
+          }
+        },
+        {
+          "Type": "Modify",
+          "Hook": {
+            "InjectionIndex": 0,
+            "RemoveCount": 0,
+            "Instructions": [
+              {
+                "OpCode": "call",
+                "OpType": "Method",
+                "Operand": "mscorlib|System.Environment|get_OSVersion"
+              },
+              {
+                "OpCode": "callvirt",
+                "OpType": "Method",
+                "Operand": "mscorlib|System.OperatingSystem|get_Platform"
+              },
+              {
+                "OpCode": "ldc_i4_2",
+                "OpType": "None",
+                "Operand": null
+              },
+              {
+                "OpCode": "ceq",
+                "OpType": "None",
+                "Operand": null
+              },
+              {
+                "OpCode": "brfalse",
+                "OpType": "Instruction",
+                "Operand": 8
+              }
+            ],
+            "HookTypeName": "Modify",
+            "Name": "ConsoleInitWinOnly [patch]",
+            "HookName": "ConsoleInitWinOnly [patch]",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "ServerConsole",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": ".ctor",
+              "ReturnType": "System.Void",
+              "Parameters": []
+            },
+            "MSILHash": "hMvSQJ3+3AqlZGiCx6FXHBprcWPcosm5l7BPHVidsBw=",
+            "BaseHookName": null,
+            "HookCategory": "_Patches"
+          }
+        },
+        {
+          "Type": "Modify",
+          "Hook": {
+            "InjectionIndex": 0,
+            "RemoveCount": 0,
+            "Instructions": [
+              {
+                "OpCode": "call",
+                "OpType": "Method",
+                "Operand": "mscorlib|System.Environment|get_OSVersion"
+              },
+              {
+                "OpCode": "callvirt",
+                "OpType": "Method",
+                "Operand": "mscorlib|System.OperatingSystem|get_Platform"
+              },
+              {
+                "OpCode": "ldc_i4_2",
+                "OpType": "None",
+                "Operand": null
+              },
+              {
+                "OpCode": "ceq",
+                "OpType": "None",
+                "Operand": null
+              },
+              {
+                "OpCode": "brfalse",
+                "OpType": "Instruction",
+                "Operand": 5
+              }
+            ],
+            "HookTypeName": "Modify",
+            "Name": "ConsoleUpdateWinOnly [patch]",
+            "HookName": "ConsoleUpdateWinOnly [patch]",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "ServerConsole",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 0,
+              "Name": "Update",
+              "ReturnType": "System.Void",
+              "Parameters": []
+            },
+            "MSILHash": "dbFxdC1i2DngvwowXIPatWsbfbfnyS1CMmTbwcK1Jh8=",
+            "BaseHookName": null,
+            "HookCategory": "_Patches"
+          }
         }
       ],
       "Modifiers": [

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -7641,6 +7641,31 @@
             "BaseHookName": null,
             "HookCategory": "_Patches"
           }
+        },
+        {
+          "Type": "Modify",
+          "Hook": {
+            "InjectionIndex": 210,
+            "RemoveCount": 9,
+            "Instructions": [],
+            "HookTypeName": "Modify",
+            "Name": "AllowNpcAttackingNpc [patch]",
+            "HookName": "AllowNpcAttackingNpc [patch]",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "BaseProjectile",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "ServerUse",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "System.Single"
+              ]
+            },
+            "MSILHash": "N+8KQI012/z3UtI6P6EAkadxLBonXARkWwOF5gQXzu8=",
+            "BaseHookName": null,
+            "HookCategory": "_Patches"
+          }
         }
       ],
       "Modifiers": [

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -730,7 +730,7 @@
                 "Network.Connection"
               ]
             },
-            "MSILHash": "cnZ7XEWiQHhPqDQEGcu18wQGz1fu9/mbQHjphlv9jOo=",
+            "MSILHash": "QJP81OICUoNhIEfNam9qyvwOEiyHcnD09UaBZqB8Jno=",
             "BaseHookName": null,
             "HookCategory": "Player"
           }
@@ -2193,7 +2193,7 @@
               "ReturnType": "System.Void",
               "Parameters": []
             },
-            "MSILHash": "CmrFxTqdHZQt2AyRHVfM0u/IZzyLPkLSE4IvjCDJLDc=",
+            "MSILHash": "frqztbYXiRf4FtqN4PRVmHJcKVRtVdeOyb4hrGdW8c8=",
             "BaseHookName": null,
             "HookCategory": "_Patches"
           }
@@ -2597,7 +2597,7 @@
                 "Network.Message"
               ]
             },
-            "MSILHash": "ZQX1IN+6BkKW+zaoxyQHkyHyHmXmEGAU5w9znbw8ElY=",
+            "MSILHash": "t3O0JEbSLIilmiVzKx82IhrOsk52VynKTaXXm/QQkJE=",
             "BaseHookName": null,
             "HookCategory": "Player"
           }
@@ -6861,7 +6861,7 @@
               "ReturnType": "System.Void",
               "Parameters": []
             },
-            "MSILHash": "CmrFxTqdHZQt2AyRHVfM0u/IZzyLPkLSE4IvjCDJLDc=",
+            "MSILHash": "frqztbYXiRf4FtqN4PRVmHJcKVRtVdeOyb4hrGdW8c8=",
             "BaseHookName": "AddGameTags [patch]",
             "HookCategory": "_Patches"
           }

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -6141,7 +6141,7 @@
             "HookName": "IOnNpcTarget",
             "AssemblyName": "Assembly-CSharp.dll",
             "TypeName": "BaseNpc",
-            "Flagged": false,
+            "Flagged": true,
             "Signature": {
               "Exposure": 0,
               "Name": "AggroClosestEnemy",

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -730,7 +730,7 @@
                 "Network.Connection"
               ]
             },
-            "MSILHash": "aQZQPnX03dTDPq/jsEfS82GBz0WrxRO+pbrEETKEn5g=",
+            "MSILHash": "AIuhaSnlHQ6mJtwpxk6uI5pRRw63rhwFFq9rbHpzF0I=",
             "BaseHookName": null,
             "HookCategory": "Player"
           }
@@ -2271,7 +2271,7 @@
               "ReturnType": "System.Void",
               "Parameters": []
             },
-            "MSILHash": "dQnhRUfe7lIh+7JhsTWAFkBFGZ+uaJLnVFnwBKIfLtI=",
+            "MSILHash": "+5o9fm5e/nUb1WmLWXOPSCAI0ouBoIKx4r5FvgWWTtc=",
             "BaseHookName": null,
             "HookCategory": "_Patches"
           }
@@ -2675,7 +2675,7 @@
                 "Network.Message"
               ]
             },
-            "MSILHash": "/K8LF87g+qm+Muko2fmVBKBp9RQmfGSCbtWTkKCoscU=",
+            "MSILHash": "M1lFVmiCqwsaU6ncuj2YUbsGweWdOAGG7gpTax7lRr4=",
             "BaseHookName": null,
             "HookCategory": "Player"
           }

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -10870,6 +10870,82 @@
             "Parameters": []
           },
           "MSILHash": ""
+        },
+        {
+          "Name": "BasePlayer::cachedCraftLevel",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "BasePlayer",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "cachedCraftLevel",
+            "FullTypeName": "System.Single BasePlayer::cachedCraftLevel",
+            "Parameters": []
+          },
+          "MSILHash": ""
+        },
+        {
+          "Name": "BasePlayer::cachedThreatLevel",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "BasePlayer",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "cachedThreatLevel",
+            "FullTypeName": "System.Single BasePlayer::cachedThreatLevel",
+            "Parameters": []
+          },
+          "MSILHash": ""
+        },
+        {
+          "Name": "BasePlayer::cachedProtection",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "BasePlayer",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "cachedProtection",
+            "FullTypeName": "ProtectionProperties BasePlayer::cachedProtection",
+            "Parameters": []
+          },
+          "MSILHash": ""
+        },
+        {
+          "Name": "BasePlayer::nextCheckTime",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "BasePlayer",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "nextCheckTime",
+            "FullTypeName": "System.Single BasePlayer::nextCheckTime",
+            "Parameters": []
+          },
+          "MSILHash": ""
         }
       ],
       "Fields": [

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -3291,7 +3291,7 @@
             "InjectionIndex": 111,
             "ReturnBehavior": 0,
             "ArgumentBehavior": 4,
-            "ArgumentString": "a0.player, l3",
+            "ArgumentString": "a0.player, l2",
             "HookTypeName": "Simple",
             "Name": "OnExplosiveDropped",
             "HookName": "OnExplosiveDropped",

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -232,7 +232,7 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 5,
+            "InjectionIndex": 0,
             "ReturnBehavior": 1,
             "ArgumentBehavior": 4,
             "ArgumentString": "a0, this",
@@ -258,7 +258,7 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 5,
+            "InjectionIndex": 0,
             "ReturnBehavior": 1,
             "ArgumentBehavior": 4,
             "ArgumentString": "a0, this",

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -730,7 +730,7 @@
                 "Network.Connection"
               ]
             },
-            "MSILHash": "EiLHZYTny1lwHboRPMU+JfypHSHyUFw1LwnFB5kSUZw=",
+            "MSILHash": "aQZQPnX03dTDPq/jsEfS82GBz0WrxRO+pbrEETKEn5g=",
             "BaseHookName": null,
             "HookCategory": "Player"
           }
@@ -995,7 +995,7 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 84,
+            "InjectionIndex": 83,
             "ReturnBehavior": 0,
             "ArgumentBehavior": 4,
             "ArgumentString": "this, a0.player",
@@ -1013,7 +1013,7 @@
                 "BaseEntity/RPCMessage"
               ]
             },
-            "MSILHash": "4E1Mzhss6qoSSfMM2j2Bj+6+IgEtmny9cH0vuod+dGE=",
+            "MSILHash": "0Qi4Y8IDRXsHxO2anKj1yEEwyjKEW4EVR8L56DIImMk=",
             "BaseHookName": null,
             "HookCategory": "Structure"
           }
@@ -1021,7 +1021,7 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 57,
+            "InjectionIndex": 56,
             "ReturnBehavior": 0,
             "ArgumentBehavior": 4,
             "ArgumentString": "this, a0.player",
@@ -1039,7 +1039,7 @@
                 "BaseEntity/RPCMessage"
               ]
             },
-            "MSILHash": "6tXxR77bLaVDP6Bm6Hfza/7b1wav0iXbwKFGnz6wKJk=",
+            "MSILHash": "awwPqDilQmvBtART+c6WvxGssuls8JLlxY7WHWn07Lc=",
             "BaseHookName": null,
             "HookCategory": "Structure"
           }
@@ -1649,7 +1649,7 @@
             "HookName": "OnItemRepair",
             "AssemblyName": "Assembly-CSharp.dll",
             "TypeName": "RepairBench",
-            "Flagged": false,
+            "Flagged": true,
             "Signature": {
               "Exposure": 2,
               "Name": "RepairItem",
@@ -2271,7 +2271,7 @@
               "ReturnType": "System.Void",
               "Parameters": []
             },
-            "MSILHash": "Gwcigyqi8KojpaEITmLUqvCOG6cIYKrlpCiFQW4zhzg=",
+            "MSILHash": "dQnhRUfe7lIh+7JhsTWAFkBFGZ+uaJLnVFnwBKIfLtI=",
             "BaseHookName": null,
             "HookCategory": "_Patches"
           }
@@ -2675,7 +2675,7 @@
                 "Network.Message"
               ]
             },
-            "MSILHash": "nBGxMTsNVVS85d3fANgaUcUIXTucbkMHpAEwUsrbr3k=",
+            "MSILHash": "/K8LF87g+qm+Muko2fmVBKBp9RQmfGSCbtWTkKCoscU=",
             "BaseHookName": null,
             "HookCategory": "Player"
           }
@@ -2702,7 +2702,7 @@
                 "System.Boolean"
               ]
             },
-            "MSILHash": "tnv0JcuUOBjDMHD0nmXf5Fe1+SwSM6CCzYc03tgwuiY=",
+            "MSILHash": "PoqqZGv74vAvQo8UewLryVgaedO9gK0X3AzcyRMbntY=",
             "BaseHookName": null,
             "HookCategory": "Server"
           }
@@ -2779,7 +2779,7 @@
                 "System.Boolean"
               ]
             },
-            "MSILHash": "tnv0JcuUOBjDMHD0nmXf5Fe1+SwSM6CCzYc03tgwuiY=",
+            "MSILHash": "PoqqZGv74vAvQo8UewLryVgaedO9gK0X3AzcyRMbntY=",
             "BaseHookName": "OnNewSave",
             "HookCategory": "Server"
           }
@@ -6237,7 +6237,7 @@
               "ReturnType": "System.Void",
               "Parameters": []
             },
-            "MSILHash": "RXQ5sU5SRO9OvkLLnYnZ21hAPLOmsSMAsNPdIAOG1Yc=",
+            "MSILHash": "9l5aDwEcoEfqRQ5LEUzsMp3/p2WtjucAtgt/L3yIrqo=",
             "BaseHookName": null,
             "HookCategory": "Entity"
           }
@@ -6657,7 +6657,7 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 128,
+            "InjectionIndex": 133,
             "ReturnBehavior": 0,
             "ArgumentBehavior": 4,
             "ArgumentString": "this, l8",
@@ -6666,14 +6666,14 @@
             "HookName": "OnFlameThrowerBurn",
             "AssemblyName": "Assembly-CSharp.dll",
             "TypeName": "FlameThrower",
-            "Flagged": false,
+            "Flagged": true,
             "Signature": {
               "Exposure": 2,
               "Name": "FlameTick",
               "ReturnType": "System.Void",
               "Parameters": []
             },
-            "MSILHash": "T3bdWLqS/KACwY+ARxlEKOxmZrmPJo3GpiyaLusOChk=",
+            "MSILHash": "fxQJavxOM8Va4MQCdBmEKC+fnUZb7xBualsmqZe6nh4=",
             "BaseHookName": null,
             "HookCategory": "Weapon"
           }
@@ -6716,7 +6716,7 @@
             "HookName": "OnFireBallDamage",
             "AssemblyName": "Assembly-CSharp.dll",
             "TypeName": "FireBall",
-            "Flagged": false,
+            "Flagged": true,
             "Signature": {
               "Exposure": 2,
               "Name": "DoRadialDamage",
@@ -6740,7 +6740,7 @@
             "HookName": "OnFireBallSpread",
             "AssemblyName": "Assembly-CSharp.dll",
             "TypeName": "FireBall",
-            "Flagged": false,
+            "Flagged": true,
             "Signature": {
               "Exposure": 2,
               "Name": "TryToSpread",
@@ -7340,31 +7340,6 @@
             "MSILHash": "hFFi4tEef/LRIwY7iX2DmEhdq9BiM/Dran5rkhjNskk=",
             "BaseHookName": null,
             "HookCategory": "Player"
-          }
-        },
-        {
-          "Type": "Modify",
-          "Hook": {
-            "InjectionIndex": 126,
-            "RemoveCount": 24,
-            "Instructions": [],
-            "HookTypeName": "Modify",
-            "Name": "FixVanillaChatOnLinux [patch]",
-            "HookName": "FixVanillaChatOnLinux [patch]",
-            "AssemblyName": "Assembly-CSharp.dll",
-            "TypeName": "ConVar.Chat",
-            "Flagged": false,
-            "Signature": {
-              "Exposure": 2,
-              "Name": "say",
-              "ReturnType": "System.Void",
-              "Parameters": [
-                "ConsoleSystem/Arg"
-              ]
-            },
-            "MSILHash": "eYFQZ4ZKL4A5hZLcaMhpg5sKhIneJTCzjX+uR4k17tI=",
-            "BaseHookName": "IOnPlayerChat [internal]",
-            "HookCategory": "_Patches"
           }
         },
         {

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -730,7 +730,7 @@
                 "Network.Connection"
               ]
             },
-            "MSILHash": "CLVm3l9dDmKTKjBg5oCOgoQ7L6wVil2vnkgJqB6OdwY=",
+            "MSILHash": "MiNENunLRnFAAuvFzFm+p+o+ABgzohUy9CYuAIivq60=",
             "BaseHookName": null,
             "HookCategory": "Player"
           }
@@ -2245,7 +2245,7 @@
               "ReturnType": "System.Void",
               "Parameters": []
             },
-            "MSILHash": "3Hb2wI371ob2C39yx64OrrEUjJKfOBZCqELiESUsxkQ=",
+            "MSILHash": "xVLkwdlwLfYSanUok51cbf/EVDranr/ZHV93mQw12RI=",
             "BaseHookName": null,
             "HookCategory": "_Patches"
           }
@@ -2649,7 +2649,7 @@
                 "Network.Message"
               ]
             },
-            "MSILHash": "IoH41udXxx8MM/4Ax+9sgERAeLWcE9Wj0JgAw550fqc=",
+            "MSILHash": "LISNFM/Zx2cV53mXVgbhqrDXm9pZt6WjuurrRdRvXgw=",
             "BaseHookName": null,
             "HookCategory": "Player"
           }
@@ -3228,7 +3228,7 @@
                 "Item"
               ]
             },
-            "MSILHash": "/8X9ZlwQSrtj5a2OUYdVFUx5PstAwQAeIwnJ+zvOKkE=",
+            "MSILHash": "kEoNyXsZ/Oy734P39m4DcrM7hzp9HDbAg9745ESVuVw=",
             "BaseHookName": null,
             "HookCategory": "Item"
           }

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -3086,7 +3086,7 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 9,
+            "InjectionIndex": 4,
             "ReturnBehavior": 1,
             "ArgumentBehavior": 4,
             "ArgumentString": "this, a0.player",
@@ -6132,7 +6132,7 @@
         {
           "Type": "Simple",
           "Hook": {
-            "InjectionIndex": 344,
+            "InjectionIndex": 345,
             "ReturnBehavior": 1,
             "ArgumentBehavior": 4,
             "ArgumentString": "this, this.AiContext.AIAgent.AttackTarget",
@@ -7130,7 +7130,7 @@
             "HookName": "OnNpcPlayerTarget",
             "AssemblyName": "Assembly-CSharp.dll",
             "TypeName": "NPCPlayerApex",
-            "Flagged": true,
+            "Flagged": false,
             "Signature": {
               "Exposure": 2,
               "Name": "UpdateTargetMemory",

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -1,6 +1,6 @@
 {
   "Name": "Rust",
-  "TargetDirectory": "D:\\Servers\\Rust\\RustDedicated_Data\\Managed",
+  "TargetDirectory": "D:\\Servers\\Rust-staging\\RustDedicated_Data\\Managed",
   "Manifests": [
     {
       "AssemblyName": "Assembly-CSharp.dll",
@@ -730,7 +730,7 @@
                 "Network.Connection"
               ]
             },
-            "MSILHash": "MiNENunLRnFAAuvFzFm+p+o+ABgzohUy9CYuAIivq60=",
+            "MSILHash": "2t/J26dIeMSaQxZFzhVh2PCar5XjBL+zw7Qt68LH7Qc=",
             "BaseHookName": null,
             "HookCategory": "Player"
           }
@@ -2245,7 +2245,7 @@
               "ReturnType": "System.Void",
               "Parameters": []
             },
-            "MSILHash": "xVLkwdlwLfYSanUok51cbf/EVDranr/ZHV93mQw12RI=",
+            "MSILHash": "U4e8rfIXzHnWxRnW8mTp3IXv4UL+jc8SJIx0kNDaVmU=",
             "BaseHookName": null,
             "HookCategory": "_Patches"
           }
@@ -2649,7 +2649,7 @@
                 "Network.Message"
               ]
             },
-            "MSILHash": "LISNFM/Zx2cV53mXVgbhqrDXm9pZt6WjuurrRdRvXgw=",
+            "MSILHash": "HWYanqpQTLCBnF2ejygrxciuRAvHX/qBEtXb20brd04=",
             "BaseHookName": null,
             "HookCategory": "Player"
           }
@@ -2676,7 +2676,7 @@
                 "System.Boolean"
               ]
             },
-            "MSILHash": "tOtlb53xTDaMxUl+HBde0Ursomf6O7L4d9u2UdFgIRU=",
+            "MSILHash": "CfrnPiioH3iVea1CijtHAedIVb+CcNPHbmsJSyjrSLU=",
             "BaseHookName": null,
             "HookCategory": "Server"
           }
@@ -2727,7 +2727,7 @@
                 "System.Boolean"
               ]
             },
-            "MSILHash": "tOtlb53xTDaMxUl+HBde0Ursomf6O7L4d9u2UdFgIRU=",
+            "MSILHash": "CfrnPiioH3iVea1CijtHAedIVb+CcNPHbmsJSyjrSLU=",
             "BaseHookName": "OnNewSave",
             "HookCategory": "Server"
           }

--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -2431,7 +2431,7 @@
                 "Item"
               ]
             },
-            "MSILHash": "rLJKbVp70JjUTUfNrML37oxakzhTvt3O9ImpgYTjhvY=",
+            "MSILHash": "KPzLKIxbmMW8fG4OG4FAmf9LSmqOJPxSWsjJCbiQX1M=",
             "BaseHookName": null,
             "HookCategory": "Weapon"
           }
@@ -5524,7 +5524,7 @@
                 "Item"
               ]
             },
-            "MSILHash": "rLJKbVp70JjUTUfNrML37oxakzhTvt3O9ImpgYTjhvY=",
+            "MSILHash": "KPzLKIxbmMW8fG4OG4FAmf9LSmqOJPxSWsjJCbiQX1M=",
             "BaseHookName": "CanCreateWorldProjectile",
             "HookCategory": "Weapon"
           }
@@ -6285,7 +6285,7 @@
               "ReturnType": "System.Void",
               "Parameters": []
             },
-            "MSILHash": "k6b4SLIrgo+NPSb+dvkqJgV4MfFEjsxmnFOXq3lIwY8=",
+            "MSILHash": "nINFsRSYIH4lILvSVZBPOkxq3nPCxDIGuKFykNeKioE=",
             "BaseHookName": null,
             "HookCategory": "Entity"
           }

--- a/src/Libraries/Covalence/RustServer.cs
+++ b/src/Libraries/Covalence/RustServer.cs
@@ -1,11 +1,12 @@
 using Facepunch;
 using Oxide.Core;
 using Oxide.Core.Libraries.Covalence;
-using Rust;
+using Steamworks;
 using System;
 using System.Globalization;
 using System.IO;
 using System.Net;
+using Utility = Oxide.Core.Utility;
 
 namespace Oxide.Game.Rust.Libraries.Covalence
 {
@@ -50,9 +51,9 @@ namespace Oxide.Game.Rust.Libraries.Covalence
                             IPAddress.TryParse(ConVar.Server.ip, out address);
                             Interface.Oxide.LogInfo($"IP address from command-line: {address}");
                         }
-                        else if (Global.SteamServer != null && Global.SteamServer.IsValid && Global.SteamServer.PublicIp != null)
+                        else if (SteamServer.IsValid && SteamServer.PublicIp != null)
                         {
-                            address = Global.SteamServer.PublicIp;
+                            address = SteamServer.PublicIp;
                             Interface.Oxide.LogInfo($"IP address from Steam query: {address}");
                         }
                         else

--- a/src/Oxide.Rust.csproj
+++ b/src/Oxide.Rust.csproj
@@ -12,7 +12,7 @@
     <PackageIconUrl>https://avatars1.githubusercontent.com/u/10712027?s=64</PackageIconUrl>
     <Copyright>Copyright (c) 2014-$([System.DateTime]::Now.Year) $(Authors)</Copyright>
     <PackageTags>gaming modding plugins unity unity3d</PackageTags>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>netstandard20</TargetFramework>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <ManagedDir>RustDedicated_Data\Managed</ManagedDir>
     <SteamAppId>258550</SteamAppId>
@@ -29,64 +29,64 @@
     <PackageReference Include="Oxide.SQLite" Version="2.0.*" />
     <PackageReference Include="Oxide.Unity" Version="2.0.*" />
     <Reference Include="Assembly-CSharp">
-      <HintPath>Dependencies\Patched\$(ManagedDir)\Assembly-CSharp.dll</HintPath>
+      <HintPath>Dependencies\Patched\$(SteamBranch)\$(ManagedDir)\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp-firstpass">
-      <HintPath>Dependencies\Patched\$(ManagedDir)\Assembly-CSharp-firstpass.dll</HintPath>
+      <HintPath>Dependencies\Patched\$(SteamBranch)\$(ManagedDir)\Assembly-CSharp-firstpass.dll</HintPath>
     </Reference>
     <Reference Include="Facepunch.Console">
-      <HintPath>Dependencies\Patched\$(ManagedDir)\Facepunch.Console.dll</HintPath>
+      <HintPath>Dependencies\Patched\$(SteamBranch)\$(ManagedDir)\Facepunch.Console.dll</HintPath>
     </Reference>
     <Reference Include="Facepunch.Network">
-      <HintPath>Dependencies\Patched\$(ManagedDir)\Facepunch.Network.dll</HintPath>
+      <HintPath>Dependencies\Patched\$(SteamBranch)\$(ManagedDir)\Facepunch.Network.dll</HintPath>
     </Reference>
     <Reference Include="Facepunch.Rcon">
-      <HintPath>Dependencies\Patched\$(ManagedDir)\Facepunch.Rcon.dll</HintPath>
+      <HintPath>Dependencies\Patched\$(SteamBranch)\$(ManagedDir)\Facepunch.Rcon.dll</HintPath>
     </Reference>
     <Reference Include="Facepunch.Steamworks">
-      <HintPath>Dependencies\Patched\$(ManagedDir)\Facepunch.Steamworks.dll</HintPath>
+      <HintPath>Dependencies\Patched\$(SteamBranch)\$(ManagedDir)\Facepunch.Steamworks.dll</HintPath>
     </Reference>
     <Reference Include="Facepunch.System">
-      <HintPath>Dependencies\Patched\$(ManagedDir)\Facepunch.System.dll</HintPath>
+      <HintPath>Dependencies\Patched\$(SteamBranch)\$(ManagedDir)\Facepunch.System.dll</HintPath>
     </Reference>
     <Reference Include="Facepunch.Unity">
-      <HintPath>Dependencies\Patched\$(ManagedDir)\Facepunch.Unity.dll</HintPath>
+      <HintPath>Dependencies\Patched\$(SteamBranch)\$(ManagedDir)\Facepunch.Unity.dll</HintPath>
     </Reference>
     <Reference Include="Facepunch.UnityEngine">
-      <HintPath>Dependencies\Patched\$(ManagedDir)\Facepunch.UnityEngine.dll</HintPath>
+      <HintPath>Dependencies\Patched\$(SteamBranch)\$(ManagedDir)\Facepunch.UnityEngine.dll</HintPath>
     </Reference>
     <Reference Include="mscorlib">
-      <HintPath>Dependencies\Patched\$(ManagedDir)\mscorlib.dll</HintPath>
+      <HintPath>Dependencies\Patched\$(SteamBranch)\$(ManagedDir)\mscorlib.dll</HintPath>
     </Reference>
     <Reference Include="NewAssembly">
-      <HintPath>Dependencies\Patched\$(ManagedDir)\NewAssembly.dll</HintPath>
+      <HintPath>Dependencies\Patched\$(SteamBranch)\$(ManagedDir)\NewAssembly.dll</HintPath>
     </Reference>
     <Reference Include="System">
-      <HintPath>Dependencies\Patched\$(ManagedDir)\System.dll</HintPath>
+      <HintPath>Dependencies\Patched\$(SteamBranch)\$(ManagedDir)\System.dll</HintPath>
     </Reference>
     <Reference Include="Rust.Data">
-      <HintPath>Dependencies\Patched\$(ManagedDir)\Rust.Data.dll</HintPath>
+      <HintPath>Dependencies\Patched\$(SteamBranch)\$(ManagedDir)\Rust.Data.dll</HintPath>
     </Reference>
     <Reference Include="Rust.Global">
-      <HintPath>Dependencies\Patched\$(ManagedDir)\Rust.Global.dll</HintPath>
+      <HintPath>Dependencies\Patched\$(SteamBranch)\$(ManagedDir)\Rust.Global.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine">
-      <HintPath>Dependencies\Patched\$(ManagedDir)\UnityEngine.dll</HintPath>
+      <HintPath>Dependencies\Patched\$(SteamBranch)\$(ManagedDir)\UnityEngine.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>Dependencies\Patched\$(ManagedDir)\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>Dependencies\Patched\$(SteamBranch)\$(ManagedDir)\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.PhysicsModule">
-      <HintPath>Dependencies\Patched\$(ManagedDir)\UnityEngine.PhysicsModule.dll</HintPath>
+      <HintPath>Dependencies\Patched\$(SteamBranch)\$(ManagedDir)\UnityEngine.PhysicsModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.TextRenderingModule">
-      <HintPath>Dependencies\Patched\$(ManagedDir)\UnityEngine.TextRenderingModule.dll</HintPath>
+      <HintPath>Dependencies\Patched\$(SteamBranch)\$(ManagedDir)\UnityEngine.TextRenderingModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UI">
-      <HintPath>Dependencies\Patched\$(ManagedDir)\UnityEngine.UI.dll</HintPath>
+      <HintPath>Dependencies\Patched\$(SteamBranch)\$(ManagedDir)\UnityEngine.UI.dll</HintPath>
     </Reference>
     <Reference Include="websocket-sharp">
-      <HintPath>Dependencies\Patched\$(ManagedDir)\websocket-sharp.dll</HintPath>
+      <HintPath>Dependencies\Patched\$(SteamBranch)\$(ManagedDir)\websocket-sharp.dll</HintPath>
     </Reference>
     <None Remove="Bundle\**; Files\**; Patched\**; **\Original\**; *.config; *.opj" />
   </ItemGroup>
@@ -108,12 +108,14 @@
   <Target Name="AfterBuild">
     <ItemGroup>
       <CoreFiles Include="$(TargetDir)\Oxide.*.dll" />
-      <PatchedFiles Include="$(ProjectDir)\Dependencies\Patched\$(ManagedDir)\Assembly-CSharp.dll" />
-      <PatchedFiles Include="$(ProjectDir)\Dependencies\Patched\$(ManagedDir)\Facepunch.Console.dll" />
-      <PatchedFiles Include="$(ProjectDir)\Dependencies\Patched\$(ManagedDir)\Facepunch.Rcon.dll" />
-      <PatchedFiles Include="$(ProjectDir)\Dependencies\Patched\$(ManagedDir)\NewAssembly.dll" />
-      <ContentFiles Include="$(SolutionDir)\packages\oxide.csharp\**\lib\any\*.*" />
-      <ContentFiles Include="$(SolutionDir)\packages\oxide.references\**\lib\any\net46\*.*" />
+      <PatchedFiles Include="$(ProjectDir)\Dependencies\Patched\$(SteamBranch)\$(ManagedDir)\Assembly-CSharp.dll" />
+      <PatchedFiles Include="$(ProjectDir)\Dependencies\Patched\$(SteamBranch)\$(ManagedDir)\Facepunch.Console.dll" />
+      <PatchedFiles Include="$(ProjectDir)\Dependencies\Patched\$(SteamBranch)\$(ManagedDir)\Facepunch.Rcon.dll" />
+      <PatchedFiles Include="$(ProjectDir)\Dependencies\Patched\$(SteamBranch)\$(ManagedDir)\NewAssembly.dll" />
+      <ContentFiles Include="$(SolutionDir)\packages\oxide.core\**\lib\$(TargetFramework)\*.*" />
+      <ContentFiles Include="$(SolutionDir)\packages\oxide.csharp\**\lib\any\*.*; $(SolutionDir)\packages\oxide.csharp\**\lib\$(TargetFramework)\*.*" />
+      <ContentFiles Include="$(SolutionDir)\packages\oxide.references\**\lib\any\net46\*.*; $(SolutionDir)\packages\oxide.references\**\lib\$(TargetFramework)\*.*" />
+      <ContentFiles Include="$(SolutionDir)\packages\oxide.unity\**\lib\$(TargetFramework)\*.*" />
       <ContentFiles Include="$(SolutionDir)\packages\oxide.mysql\**\lib\any\MySql.*.dll; $(SolutionDir)\packages\oxide.mysql\**\lib\any\System.*.dll" />
       <ContentFiles Include="$(SolutionDir)\packages\oxide.mysql\**\lib\$(TargetFramework)\*.*" />
       <ContentFiles Include="$(SolutionDir)\packages\oxide.sqlite\**\lib\any\*.*; $(SolutionDir)\packages\oxide.sqlite\**\lib\$(TargetFramework)\*.*" />
@@ -133,6 +135,9 @@
     <ReadLinesFromFile File="$(SolutionDir)\.deploy">
       <Output PropertyName="DeployPath" TaskParameter="Lines" />
     </ReadLinesFromFile>
+    <PropertyGroup>
+      <DeployPath Condition="'$(SteamBranch).Lower()' != 'public'">$(DeployPath)-$(SteamBranch)</DeployPath>
+    </PropertyGroup>
     <ItemGroup>
       <DeployFiles Include="$(ProjectDir)\bin\Bundle\$(PackageId)\**\*.*" />
     </ItemGroup>

--- a/src/RustCommands.cs
+++ b/src/RustCommands.cs
@@ -703,9 +703,7 @@ namespace Oxide.Game.Rust
         {
             if (player.IsServer)
             {
-                player.Reply($"Protocol: {Server.Protocol}\nBuild Date: {BuildInfo.Current.BuildDate}\n" +
-                $"Unity Version: {UnityEngine.Application.unityVersion}\nChangeset: {BuildInfo.Current.Scm.ChangeId}\n" +
-                $"Branch: {BuildInfo.Current.Scm.Branch}\nOxide.Rust Version: {RustExtension.AssemblyVersion}");
+                player.Reply("Oxide.Rust Version: " + RustExtension.AssemblyVersion);
             }
             else
             {

--- a/src/RustHooks.cs
+++ b/src/RustHooks.cs
@@ -344,6 +344,15 @@ namespace Oxide.Game.Rust
         }
 
         /// <summary>
+        /// Called when the player is authenticating
+        /// </summary>
+        /// <param name="connection"></param>
+        private void OnClientAuth(Connection connection)
+        {
+            connection.username = Regex.Replace(connection.username, @"<[^>]*>", string.Empty);
+        }
+
+        /// <summary>
         /// Called when the player has disconnected
         /// </summary>
         /// <param name="player"></param>

--- a/src/RustHooks.cs
+++ b/src/RustHooks.cs
@@ -270,16 +270,13 @@ namespace Oxide.Game.Rust
         /// Called when the player sends a chat message
         /// </summary>
         /// <param name="arg"></param>
+        /// <param name="message"></param>
         /// <returns></returns>
         [HookMethod("IOnPlayerChat")]
-        private object IOnPlayerChat(ConsoleSystem.Arg arg)
+        private object IOnPlayerChat(ConsoleSystem.Arg arg, string message)
         {
-            // Get the full chat string
-            string str = arg.GetString(0).Trim();
-            if (string.IsNullOrEmpty(str))
-            {
-                return true;
-            }
+            // Store escaped message
+            arg.Args[0] = message.EscapeRichText();
 
             // Get player objects
             BasePlayer player = arg.Connection.player as BasePlayer;
@@ -291,7 +288,7 @@ namespace Oxide.Game.Rust
 
             // Call game and covalence hooks
             object chatSpecific = Interface.CallHook("OnPlayerChat", arg);
-            object chatCovalence = Interface.CallHook("OnUserChat", iplayer, str);
+            object chatCovalence = Interface.CallHook("OnUserChat", iplayer, message);
             return chatSpecific ?? chatCovalence; // TODO: Fix 'RustCore' hook conflict when both return
         }
 


### PR DESCRIPTION
Hello.

CanAdministerVending [npc] - adding hook for NPCVendingMachine/InvisibleVendingMachine
CanGiveSoldItem/CanGiveSoldItem [npc] - executed before the delivery of goods to the player
CanRenameShop - executed before rename VendingMachine

Tested, no problems detected.

Thank.