### PR TITLE
Add 2 new hooks

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -4661,6 +4661,30 @@
         {
           "Type": "Simple",
           "Hook": {
+            "InjectionIndex": 0,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 0,
+            "ArgumentString": null,
+            "HookTypeName": "Simple",
+            "Name": "OnFindSpawnPoint",
+            "HookName": "OnFindSpawnPoint",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "ServerMgr",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "FindSpawnPoint",
+              "ReturnType": "BasePlayer.SpawnPoint",
+              "Parameters": []
+            },
+            "MSILHash": "VmBYJrGdCSWoemzP7ZbEwGe0M/cB4oXynbvYWqCbKTo=",
+            "BaseHookName": null,
+            "HookCategory": "Player"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
             "InjectionIndex": 9,
             "ReturnBehavior": 1,
             "ArgumentBehavior": 4,
@@ -5416,6 +5440,32 @@
             "HookTypeName": "Simple",
             "Name": "OnPlayerActiveItemChanged",
             "HookName": "OnPlayerActiveItemChanged",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "BasePlayer",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 3,
+              "Name": "UpdateActiveItem",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "System.UInt32"
+              ]
+            },
+            "MSILHash": "jc/s/C+L+BAzdNjmcKYiQhC8jUmoZXHwxe4pEJ5cOHo=",
+            "BaseHookName": null,
+            "HookCategory": "Player"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 0,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, a0",
+            "HookTypeName": "Simple",
+            "Name": "CanPlayerChangeActiveItem",
+            "HookName": "CanPlayerChangeActiveItem",
             "AssemblyName": "Assembly-CSharp.dll",
             "TypeName": "BasePlayer",
             "Flagged": false,


### PR DESCRIPTION
OnFindSpawnPoint()
  - Return BasePlayer.SpawnPoint to override.
  - Good for minigame servers to override native spawnpoint finding method (removes overhead)

CanPlayerChangeActiveItem(uint newItem)
  - Return non null to cancel

