### PR TITLE
Two new hooks and 2 exposed fields

### DIFF
--- a/resources/Rust.opj
+++ b/resources/Rust.opj
@@ -9112,6 +9112,58 @@
             "BaseHookName": null,
             "HookCategory": "Player"
           }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 54,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, a0.player, v1",
+            "HookTypeName": "Simple",
+            "Name": "OnCardSwiped",
+            "HookName": "OnCardSwiped",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "CardReader",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "ServerCardSwiped",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "BaseEntity/RPCMessage"
+              ]
+            },
+            "MSILHash": "MQr5Pu4AUe5YTmJSramofQeNuf3yu00vozozf0ppb2I=",
+            "BaseHookName": null,
+            "HookCategory": "Entity"
+          }
+        },
+        {
+          "Type": "Simple",
+          "Hook": {
+            "InjectionIndex": 4,
+            "ReturnBehavior": 1,
+            "ArgumentBehavior": 4,
+            "ArgumentString": "this, a0.player",
+            "HookTypeName": "Simple",
+            "Name": "OnButtonPress",
+            "HookName": "OnButtonPress",
+            "AssemblyName": "Assembly-CSharp.dll",
+            "TypeName": "PressButton",
+            "Flagged": false,
+            "Signature": {
+              "Exposure": 2,
+              "Name": "Press",
+              "ReturnType": "System.Void",
+              "Parameters": [
+                "BaseEntity/RPCMessage"
+              ]
+            },
+            "MSILHash": "Gw+u289ks4NbZ7iaIK0xXPRja0OffHtyuF5p5HbEznI=",
+            "BaseHookName": null,
+            "HookCategory": "Entity"
+          }
         }
       ],
       "Modifiers": [
@@ -12643,6 +12695,44 @@
             ],
             "Name": "cachedFuelTime",
             "FullTypeName": "System.Single DieselEngine::cachedFuelTime",
+            "Parameters": []
+          },
+          "MSILHash": ""
+        },
+        {
+          "Name": "BaseEntity::triggers",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "BaseEntity",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              1
+            ],
+            "Name": "triggers",
+            "FullTypeName": "System.Collections.Generic.List`1<TriggerBase> BaseEntity::triggers",
+            "Parameters": []
+          },
+          "MSILHash": ""
+        },
+        {
+          "Name": "SpawnGroup::spawnClock",
+          "AssemblyName": "Assembly-CSharp.dll",
+          "TypeName": "SpawnGroup",
+          "Type": 0,
+          "TargetExposure": [
+            2
+          ],
+          "Flagged": false,
+          "Signature": {
+            "Exposure": [
+              0
+            ],
+            "Name": "spawnClock",
+            "FullTypeName": "LocalClock SpawnGroup::spawnClock",
             "Parameters": []
           },
           "MSILHash": ""


### PR DESCRIPTION
Hooks for I/O puzzle entities:
`object OnCardSwiped(CardReader, BasePlayer, KeyCard)`
Called every time a player uses a KeyCard on a CardReader.
The card reader must be powered.
Returning non-null value cancels the default behavior.
`object OnButtonPress(PressButton, BasePlayer)`
Called every time a player about to push a button.
The button should not be in a pressed state.
Returning non-null value cancels the default behavior.

Fields:
`SpawnGroup::spawnClock`
Exposes internal event scheduler. Can be useful for modifying respawns.
`BaseEntity::triggers`
Exposes the list of all triggers in which the BaseEntity is.